### PR TITLE
strcmp_equal: Skip lint for g_strcmp0

### DIFF
--- a/src/rules/strcmp_equal.rs
+++ b/src/rules/strcmp_equal.rs
@@ -108,7 +108,7 @@ impl StrcmpForStringEqual {
         parent_node: Node,
         violations: &mut Vec<Violation>,
     ) {
-        // Check if strcmp_side is a call to strcmp or g_strcmp0
+        // Check if strcmp_side is a call to strcmp
         if strcmp_side.kind() != "call_expression" {
             return;
         }
@@ -118,7 +118,7 @@ impl StrcmpForStringEqual {
         };
 
         let func_name = ast_context.get_node_text(function, source);
-        if func_name != "strcmp" && func_name != "g_strcmp0" {
+        if func_name != "strcmp" {
             return;
         }
 


### PR DESCRIPTION
unlike g_str_equal (and strcmp), g_strcmp0 handles NULL gracefully and should not be replaced with the former.