### PR TITLE
rules: Add use_g_string_free_and_steal

### DIFF
--- a/gobject-lint.toml
+++ b/gobject-lint.toml
@@ -82,3 +82,6 @@ suggest_g_autoptr_inline_cleanup = true
 
 # Suggest g_autofree for string/buffer types instead of manual g_free (requires GLib >= 2.44)
 suggest_g_autofree = true
+
+# Suggest use_g_string_free_and_steal instead of g_string_free with FALSE as a parameter (requires GLib >= 2.76)
+use_g_string_free_and_steal = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -182,6 +182,9 @@ pub struct RulesConfig {
 
     #[serde(default)]
     pub suggest_g_autofree: RuleConfig,
+
+    #[serde(default)]
+    pub use_g_string_free_and_steal: RuleConfig,
 }
 
 impl Config {

--- a/src/rules/mod.rs
+++ b/src/rules/mod.rs
@@ -19,6 +19,7 @@ pub mod use_clear_functions;
 pub mod use_g_clear_error;
 pub mod use_g_set_str;
 pub mod use_g_strcmp0;
+pub mod use_g_string_free_and_steal;
 
 #[derive(Debug, Clone)]
 pub struct Violation {

--- a/src/rules/strcmp_equal.rs
+++ b/src/rules/strcmp_equal.rs
@@ -111,7 +111,7 @@ impl StrcmpForStringEqual {
         parent_node: Node,
         violations: &mut Vec<Violation>,
     ) {
-        // Check if strcmp_side is a call to strcmp or g_strcmp0
+        // Check if strcmp_side is a call to strcmp
         if strcmp_side.kind() != "call_expression" {
             return;
         }
@@ -121,7 +121,7 @@ impl StrcmpForStringEqual {
         };
 
         let func_name = ast_context.get_node_text(function, source);
-        if func_name != "strcmp" && func_name != "g_strcmp0" {
+        if func_name != "strcmp" {
             return;
         }
 

--- a/src/rules/use_g_string_free_and_steal.rs
+++ b/src/rules/use_g_string_free_and_steal.rs
@@ -1,0 +1,83 @@
+use tree_sitter::Node;
+
+use super::Rule;
+use crate::{ast_context::AstContext, config::Config, rules::Violation};
+
+pub struct UseGStringFreeAndSteal;
+
+impl Rule for UseGStringFreeAndSteal {
+    fn name(&self) -> &'static str {
+        "use_g_string_free_and_steal"
+    }
+
+    fn description(&self) -> &'static str {
+        "Suggests g_string_free_and_steal instead of g_string_free (..., FALSE) for better readability"
+    }
+
+    fn check_all(
+        &self,
+        ast_context: &AstContext,
+        _config: &Config,
+        violations: &mut Vec<Violation>,
+    ) {
+        for (path, file) in ast_context.iter_c_files() {
+            for func in &file.functions {
+                if !func.is_definition {
+                    continue;
+                }
+
+                if let Some(func_source) = ast_context.get_function_source(path, func) {
+                    if let Some(tree) = ast_context.parse_c_source(func_source) {
+                        self.check_node(
+                            ast_context,
+                            tree.root_node(),
+                            func_source,
+                            path,
+                            func.line,
+                            violations,
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl UseGStringFreeAndSteal {
+    fn check_node(
+        &self,
+        ast_context: &AstContext,
+        node: Node,
+        source: &[u8],
+        file_path: &std::path::Path,
+        base_line: usize,
+        violations: &mut Vec<Violation>,
+    ) {
+        if let Some(call) = ast_context.find_function_call_by_name(node, &["g_string_free"], source)
+        {
+            if let Some(args) = call.child_by_field_name("arguments") {
+                let mut cursor = args.walk();
+                let mut children = args
+                    .children(&mut cursor)
+                    .filter(|c| !matches!(c.kind(), "(" | ")" | ","));
+                if let (Some(first), Some(second)) = (children.next(), children.next()) {
+                    let second = ast_context.get_node_text(second, source);
+
+                    if matches!(second.as_str(), "FALSE" | "false" | "0") {
+                        let first = ast_context.get_node_text(first, source);
+
+                        let position = call.start_position();
+                        violations.push(self.violation(
+                            file_path,
+                            base_line + position.row,
+                            position.column + 1,
+                            format!(
+                                "Consider using g_string_free_and_steal({first}) instead of g_string_free({first}, {second}) for readability",
+                            ),
+                        ));
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -17,7 +17,8 @@ use crate::{
         suggest_g_autoptr_inline::SuggestGAutoptrInline,
         unnecessary_null_check::UnnecessaryNullCheck, use_clear_functions::UseClearFunctions,
         use_g_clear_error::SuggestGAutoptrError, use_g_set_str::UseGSetStr,
-        use_g_strcmp0::UseGStrcmp0, Rule, Violation,
+        use_g_strcmp0::UseGStrcmp0, use_g_string_free_and_steal::UseGStringFreeAndSteal, Rule,
+        Violation,
     },
 };
 
@@ -98,6 +99,7 @@ macro_rules! for_each_rule {
             (suggest_g_autoptr_goto_cleanup, SuggestGAutoptrGoto, 2, 44),
             (suggest_g_autoptr_inline_cleanup, SuggestGAutoptrInline, 2, 44),
             (suggest_g_autofree, SuggestGAutofree, 2, 44),
+            (use_g_string_free_and_steal, UseGStringFreeAndSteal, 2, 76),
         }
     };
 }


### PR DESCRIPTION
From g_string_free docs:

> Instead of passing `FALSE` to this function, consider using `g_string_free_and_steal()`.

Note that g_string_free_and_steal was introduced in glib 2.76.