### PR TITLE
scanner: Have more exhaustive logic for apply_msvc_compatibility

### DIFF
--- a/src/scanner.rs
+++ b/src/scanner.rs
@@ -205,13 +205,12 @@ fn apply_msvc_compatibility(
     requires_auto_cleanup: bool,
     configured_level: crate::config::RuleLevel,
 ) -> crate::config::RuleLevel {
-    if !config.msvc_compatible {
-        return configured_level;
-    }
-
-    // Enable no_g_auto_macros
-    if rule_name == "no_g_auto_macros" {
-        return crate::config::RuleLevel::Error;
+    match (rule_name, config.msvc_compatible) {
+        ("no_g_auto_macros", false) => return crate::config::RuleLevel::Ignore,
+        ("no_g_auto_macros", true) => return crate::config::RuleLevel::Error,
+        (_, false) => return configured_level,
+        // Continue
+        (_, true) => (),
     }
 
     // Disable all rules that require auto cleanup attributes


### PR DESCRIPTION
Previously if we had msvc_compatible=false we'd return the configured level early, but that doesn't account for the default level of the rules being warn. This would cause both g_auto and no_g_auto rules to be set to warn simultaneously.

Add a check for no_g_auto specifically and set its level based on the msvc_compatible config.

Otherwise, proceed with the existing logic.

Close #59