### PR TITLE
Add space_before_paren config option for function call formatting

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -52,7 +52,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, Deserialize, Default)]
+#[derive(Debug, Clone, Deserialize)]
 pub struct Config {
     #[serde(default)]
     pub rules: RulesConfig,
@@ -89,6 +89,32 @@ pub struct Config {
     /// Opt-in rules always default to "ignore" regardless of this setting.
     /// Per-rule `level` settings override this.
     pub default_level: Option<RuleLevel>,
+
+    /// Whether to add a space before '(' in function call replacements.
+    /// Default is true (GLib coding style: `g_new (Type, 1)`).
+    /// Set to false for no space: `g_new(Type, 1)`.
+    #[serde(default = "default_true")]
+    pub space_before_paren: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            rules: RulesConfig::default(),
+            ignore: Vec::new(),
+            min_glib_version: None,
+            msvc_compatible: false,
+            format: None,
+            editor_url: None,
+            build_dir: None,
+            default_level: None,
+            space_before_paren: true,
+        }
+    }
 }
 
 /// Rule severity level
@@ -249,6 +275,19 @@ macro_rules! impl_rules_config {
 for_each_rule!(impl_rules_config);
 
 impl Config {
+    pub fn paren_sep(&self) -> &'static str {
+        if self.space_before_paren { " " } else { "" }
+    }
+
+    pub fn format_call(&self, func_name: &str, args: &[&str]) -> String {
+        let sep = self.paren_sep();
+        if args.is_empty() {
+            format!("{func_name}{sep}()")
+        } else {
+            format!("{func_name}{sep}({})", args.join(", "))
+        }
+    }
+
     pub fn load(path: &Path) -> Result<Self> {
         if !path.exists() {
             // Return default config if file doesn't exist

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,11 @@ struct Args {
     /// to read from stdin). Useful for CI to report only on PR changes.
     #[arg(long, value_name = "FILE")]
     diff: Option<PathBuf>,
+
+    /// Remove space before '(' in generated replacements
+    /// (default has space per GLib style: "g_new (x, 1)")
+    #[arg(long)]
+    no_space_before_paren: bool,
 }
 
 /// Parse GLib version string for clap
@@ -135,6 +140,11 @@ fn main() -> Result<()> {
     // Apply --msvc-compatible if specified (overrides config)
     if args.msvc_compatible {
         config.msvc_compatible = true;
+    }
+
+    // Apply --no-space-before-paren if specified (overrides config)
+    if args.no_space_before_paren {
+        config.space_before_paren = false;
     }
 
     // Apply --only filter if specified

--- a/src/rules/property_enum_convention.rs
+++ b/src/rules/property_enum_convention.rs
@@ -54,7 +54,6 @@ impl Rule for PropertyEnumConvention {
         config: &Config,
         violations: &mut Vec<Violation>,
     ) {
-        // Get style configuration (default to "typed")
         let rule_config = &config.rules.property_enum_convention;
         let style = rule_config
             .options
@@ -63,7 +62,7 @@ impl Rule for PropertyEnumConvention {
             .unwrap_or("typed");
 
         match style {
-            "typed" => self.check_all_typed_style(ast_context, violations),
+            "typed" => self.check_all_typed_style(ast_context, config, violations),
             "legacy" => self.check_all_legacy_style(ast_context, violations),
             _ => {
                 // Invalid style, default to legacy
@@ -75,7 +74,12 @@ impl Rule for PropertyEnumConvention {
 
 impl PropertyEnumConvention {
     /// Check using modern typed enum style (PROP_FOO = 1, no PROP_0/N_PROPS)
-    fn check_all_typed_style(&self, ast_context: &AstContext, violations: &mut Vec<Violation>) {
+    fn check_all_typed_style(
+        &self,
+        ast_context: &AstContext,
+        config: &Config,
+        violations: &mut Vec<Violation>,
+    ) {
         for (path, file) in ast_context.iter_all_files() {
             // Collect N_PROPS names from enums that will be transformed
             // (skip override pattern enums and already-modern enums)
@@ -279,7 +283,8 @@ impl PropertyEnumConvention {
                                         array_arg.to_source_string(&file.source)
                                     && array_names.contains(&array_name)
                                 {
-                                    let replacement = format!("G_N_ELEMENTS ({})", array_name);
+                                    let replacement =
+                                        config.format_call("G_N_ELEMENTS", &[array_name]);
                                     fixes.push(Fix::new(
                                         arg.location().start_byte,
                                         arg.location().end_byte,

--- a/src/rules/use_clear_functions.rs
+++ b/src/rules/use_clear_functions.rs
@@ -140,29 +140,29 @@ impl ClearMapping {
     }
 }
 
-fn format_replacement(mapping: &ClearMapping, var_name: &str, obj: Option<&str>) -> String {
-    match mapping.replacement {
-        ClearReplacement::Object => format!("g_clear_object (&{});", var_name),
+fn format_replacement(
+    mapping: &ClearMapping,
+    var_name: &str,
+    obj: Option<&str>,
+    config: &Config,
+) -> String {
+    let addr = format!("&{var_name}");
+    let call = match mapping.replacement {
+        ClearReplacement::Object => config.format_call("g_clear_object", &[&addr]),
         ClearReplacement::Pointer => {
-            format!("g_clear_pointer (&{}, {});", var_name, mapping.source_func)
+            config.format_call("g_clear_pointer", &[&addr, mapping.source_func])
         }
         ClearReplacement::HandleId => {
-            format!(
-                "g_clear_handle_id (&{}, {});",
-                var_name, mapping.source_func
-            )
+            config.format_call("g_clear_handle_id", &[&addr, mapping.source_func])
         }
         ClearReplacement::SignalHandler => {
             let obj = obj.unwrap_or("obj");
-            format!("g_clear_signal_handler (&{}, {});", var_name, obj)
+            config.format_call("g_clear_signal_handler", &[&addr, obj])
         }
-        ClearReplacement::WeakPointer => {
-            format!("g_clear_weak_pointer (&{});", var_name)
-        }
-        ClearReplacement::List { clear_func } => {
-            format!("{} (&{}, NULL);", clear_func, var_name)
-        }
-    }
+        ClearReplacement::WeakPointer => config.format_call("g_clear_weak_pointer", &[&addr]),
+        ClearReplacement::List { clear_func } => config.format_call(clear_func, &[&addr, "NULL"]),
+    };
+    format!("{call};")
 }
 
 pub struct UseClearFunctions;
@@ -327,7 +327,7 @@ impl UseClearFunctions {
                 continue;
             }
 
-            let replacement = format_replacement(mapping, var_name, None);
+            let replacement = format_replacement(mapping, var_name, None, config);
             let message = format!(
                 "Use {} instead of {} and NULL/zero assignment",
                 replacement.trim_end_matches(';'),
@@ -384,7 +384,7 @@ impl UseClearFunctions {
             return false;
         }
 
-        let replacement = format_replacement(&mapping, checked_var, None);
+        let replacement = format_replacement(&mapping, checked_var, None, config);
         let message = format!(
             "Use {} instead of manual NULL check, unref, and assignment",
             replacement.trim_end_matches(';')
@@ -512,7 +512,7 @@ impl UseClearFunctions {
         let cond_id = if_stmt.extract_nonzero_check_variable(source);
 
         for (var_name, mapping, first_loc, second_loc) in conversions {
-            let replacement = format_replacement(&mapping, var_name, None);
+            let replacement = format_replacement(&mapping, var_name, None, config);
             let message = format!(
                 "Use {} instead of {} and zero assignment",
                 replacement.trim_end_matches(';'),
@@ -666,7 +666,7 @@ impl UseClearFunctions {
             return false;
         }
 
-        let replacement = format_replacement(&signal_mapping, handler_id, Some(obj));
+        let replacement = format_replacement(&signal_mapping, handler_id, Some(obj), config);
         let message = format!(
             "Use {} instead of if-guarded g_signal_handler_disconnect",
             replacement.trim_end_matches(';')
@@ -708,7 +708,7 @@ impl UseClearFunctions {
             return false;
         }
 
-        let replacement = format_replacement(&signal_mapping, handler_id, Some(obj));
+        let replacement = format_replacement(&signal_mapping, handler_id, Some(obj), config);
         let message = format!(
             "Use {} instead of g_signal_handler_disconnect and zeroing the ID",
             replacement.trim_end_matches(';')
@@ -762,7 +762,7 @@ impl UseClearFunctions {
             return false;
         }
 
-        let replacement = format_replacement(&signal_mapping, handler_id, Some(obj));
+        let replacement = format_replacement(&signal_mapping, handler_id, Some(obj), config);
         let message = format!(
             "Use {} instead of g_signal_handler_disconnect (also zeroes the stored ID)",
             replacement.trim_end_matches(';')

--- a/src/rules/use_g_ascii_functions.rs
+++ b/src/rules/use_g_ascii_functions.rs
@@ -47,7 +47,7 @@ impl Rule for UseGAsciiFunctions {
     fn check_func_impl(
         &self,
         _ast_context: &AstContext,
-        _config: &Config,
+        config: &Config,
         func: &gobject_ast::top_level::FunctionDefItem,
         file: &gobject_ast::FileModel,
         violations: &mut Vec<Violation>,
@@ -60,18 +60,15 @@ impl Rule for UseGAsciiFunctions {
             if let Some(func_name) = call.function_name_str()
                 && let Some(replacement) = g_ascii_replacement(func_name)
             {
+                let args: Vec<_> = call
+                    .arguments
+                    .iter()
+                    .filter_map(|arg| arg.to_source_string(source))
+                    .collect();
                 let fix = Fix::new(
                     call.location.start_byte,
                     call.location.end_byte,
-                    format!(
-                        "{} ({})",
-                        replacement,
-                        call.arguments
-                            .iter()
-                            .filter_map(|arg| arg.to_source_string(source))
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    ),
+                    config.format_call(replacement, &args),
                 );
 
                 violations.push(self.violation_with_fix(

--- a/src/rules/use_g_bytes_unref_to_data.rs
+++ b/src/rules/use_g_bytes_unref_to_data.rs
@@ -28,13 +28,13 @@ impl Rule for UseGBytesUnrefToData {
     fn check_func_impl(
         &self,
         _ast_context: &AstContext,
-        _config: &Config,
+        config: &Config,
         func: &gobject_ast::top_level::FunctionDefItem,
         file: &gobject_ast::FileModel,
         violations: &mut Vec<Violation>,
     ) {
         Statement::walk_pairs(&func.body_statements, &mut |stmt1, stmt2| {
-            self.try_bytes_pattern(stmt1, stmt2, file, violations);
+            self.try_bytes_pattern(stmt1, stmt2, config, file, violations);
         });
     }
 }
@@ -45,6 +45,7 @@ impl UseGBytesUnrefToData {
         &self,
         stmt1: &Statement,
         stmt2: &Statement,
+        config: &Config,
         file: &gobject_ast::FileModel,
         violations: &mut Vec<Violation>,
     ) {
@@ -64,14 +65,10 @@ impl UseGBytesUnrefToData {
         };
 
         // Build the replacement
-        let replacement = format!(
-            "{} = g_bytes_unref_to_data ({}, {});",
-            dest, bytes_var, size_arg
-        );
-        let message = format!(
-            "Use g_bytes_unref_to_data({}, {}) instead of g_bytes_get_data() followed by g_bytes_unref()",
-            bytes_var, size_arg
-        );
+        let call = config.format_call("g_bytes_unref_to_data", &[bytes_var, size_arg]);
+        let replacement = format!("{dest} = {call};");
+        let message =
+            format!("Use {call} instead of g_bytes_get_data() followed by g_bytes_unref()");
         // Use two separate fixes to preserve comments between statements
         let stmt1_end = stmt1.location().find_semicolon_end(&file.source);
         let fixes = vec![

--- a/src/rules/use_g_new.rs
+++ b/src/rules/use_g_new.rs
@@ -28,13 +28,13 @@ impl Rule for UseGNew {
     fn check_func_impl(
         &self,
         _ast_context: &AstContext,
-        _config: &Config,
+        config: &Config,
         func: &gobject_ast::top_level::FunctionDefItem,
         file: &gobject_ast::FileModel,
         violations: &mut Vec<Violation>,
     ) {
         for call in func.find_calls(&["g_malloc", "g_malloc0"]) {
-            self.check_call(file, call, violations);
+            self.check_call(config, file, call, violations);
         }
     }
 }
@@ -42,6 +42,7 @@ impl Rule for UseGNew {
 impl UseGNew {
     fn check_call(
         &self,
+        config: &Config,
         file: &gobject_ast::FileModel,
 
         call: &gobject_ast::CallExpression,
@@ -73,7 +74,7 @@ impl UseGNew {
             "g_new"
         };
 
-        let replacement = format!("{} ({}, 1)", suggested_func, type_name);
+        let replacement = config.format_call(suggested_func, &[type_name, "1"]);
         let message = format!(
             "Use {} instead of {}(sizeof({})) for type safety",
             replacement, func_name, type_name

--- a/src/rules/use_g_object_class_install_properties.rs
+++ b/src/rules/use_g_object_class_install_properties.rs
@@ -28,7 +28,7 @@ impl Rule for UseGObjectClassInstallProperties {
     fn check_enum(
         &self,
         _ast_context: &AstContext,
-        _config: &Config,
+        config: &Config,
         enum_info: &gobject_ast::EnumInfo,
         file: &gobject_ast::FileModel,
         violations: &mut Vec<Violation>,
@@ -55,6 +55,7 @@ impl Rule for UseGObjectClassInstallProperties {
         }
 
         let fixes = self.generate_fixes(
+            config,
             file,
             func,
             &install_property_calls,
@@ -89,6 +90,7 @@ impl Rule for UseGObjectClassInstallProperties {
 impl UseGObjectClassInstallProperties {
     fn generate_fixes(
         &self,
+        config: &Config,
         file: &gobject_ast::FileModel,
         class_init: &gobject_ast::top_level::FunctionDefItem,
         install_calls: &[&gobject_ast::CallExpression],
@@ -217,7 +219,8 @@ impl UseGObjectClassInstallProperties {
                 // Direct call pattern: g_object_class_install_property(...,
                 // g_param_spec_xxx(...))
                 let func_name = param_spec_call.function_name(source);
-                let new_line_prefix = format!("{}[{}] = {} (", array_name, prop_id, func_name);
+                let sep = config.paren_sep();
+                let new_line_prefix = format!("{}[{}] = {}{sep}(", array_name, prop_id, func_name);
                 let target_column = indentation.len() + new_line_prefix.len();
 
                 let Some(param_spec_text) = param_spec_arg.to_source_string(source) else {
@@ -247,7 +250,9 @@ impl UseGObjectClassInstallProperties {
 
                     // Use the g_param_spec call from the assignment
                     let func_name = g_param_spec_call.function_name(source);
-                    let new_line_prefix = format!("{}[{}] = {} (", array_name, prop_id, func_name);
+                    let sep = config.paren_sep();
+                    let new_line_prefix =
+                        format!("{}[{}] = {}{sep}(", array_name, prop_id, func_name);
                     // Note: indentation is not included because it stays in place during
                     // replacement
                     let assignment_indent = statement_location.extract_indentation(source);
@@ -325,10 +330,11 @@ impl UseGObjectClassInstallProperties {
                 return fixes;
             };
 
-            let install_properties_call = format!(
-                "\n\n{}g_object_class_install_properties ({}, {}, {});",
-                indentation, object_class_var, n_props_name, array_name
+            let install_call = config.format_call(
+                "g_object_class_install_properties",
+                &[object_class_var, &n_props_name, &array_name],
             );
+            let install_properties_call = format!("\n\n{indentation}{install_call};");
             let last_stmt_end = last_stmt.location().find_semicolon_end(source);
             fixes.push(Fix::new(
                 last_stmt_end,

--- a/src/rules/use_g_set_object.rs
+++ b/src/rules/use_g_set_object.rs
@@ -28,13 +28,13 @@ impl Rule for UseGSetObject {
     fn check_func_impl(
         &self,
         _ast_context: &AstContext,
-        _config: &Config,
+        config: &Config,
         func: &gobject_ast::top_level::FunctionDefItem,
         file: &gobject_ast::FileModel,
         violations: &mut Vec<Violation>,
     ) {
         Statement::walk_pairs(&func.body_statements, &mut |s1, s2| {
-            self.try_clear_then_ref(s1, s2, file, violations);
+            self.try_clear_then_ref(s1, s2, config, file, violations);
         });
     }
 }
@@ -46,6 +46,7 @@ impl UseGSetObject {
         &self,
         s1: &Statement,
         s2: &Statement,
+        config: &Config,
         file: &gobject_ast::FileModel,
         violations: &mut Vec<Violation>,
     ) -> bool {
@@ -76,9 +77,13 @@ impl UseGSetObject {
         // - If var is GObject* (needs_deref=false), use &var
         // - If var is GObject** (needs_deref=true), use var directly
         let replacement = if needs_deref {
-            format!("g_set_object ({var_name}, {new_val});")
+            format!(
+                "{};",
+                config.format_call("g_set_object", &[var_name, new_val])
+            )
         } else {
-            format!("g_set_object (&{var_name}, {new_val});")
+            let addr = format!("&{var_name}");
+            format!("{};", config.format_call("g_set_object", &[&addr, new_val]))
         };
 
         // Use two separate fixes to preserve comments between statements

--- a/src/rules/use_g_set_str.rs
+++ b/src/rules/use_g_set_str.rs
@@ -28,13 +28,13 @@ impl Rule for UseGSetStr {
     fn check_func_impl(
         &self,
         _ast_context: &AstContext,
-        _config: &Config,
+        config: &Config,
         func: &gobject_ast::top_level::FunctionDefItem,
         file: &gobject_ast::FileModel,
         violations: &mut Vec<Violation>,
     ) {
         Statement::walk_pairs(&func.body_statements, &mut |s1, s2| {
-            self.try_free_then_strdup(s1, s2, file, violations);
+            self.try_free_then_strdup(s1, s2, config, file, violations);
         });
     }
 }
@@ -45,6 +45,7 @@ impl UseGSetStr {
         &self,
         s1: &Statement,
         s2: &Statement,
+        config: &Config,
         file: &gobject_ast::FileModel,
         violations: &mut Vec<Violation>,
     ) -> bool {
@@ -62,7 +63,8 @@ impl UseGSetStr {
             return false;
         }
 
-        let replacement = format!("g_set_str (&{var_name}, {new_val});");
+        let addr = format!("&{var_name}");
+        let replacement = format!("{};", config.format_call("g_set_str", &[&addr, new_val]));
         let message = format!("Use {replacement} instead of g_free and g_strdup");
         // Use two separate fixes to preserve comments between statements
         let s2_end = s2.location().find_semicolon_end(&file.source);

--- a/src/rules/use_g_settings_typed.rs
+++ b/src/rules/use_g_settings_typed.rs
@@ -28,14 +28,14 @@ impl Rule for UseGSettingsTyped {
     fn check_func_impl(
         &self,
         _ast_context: &AstContext,
-        _config: &Config,
+        config: &Config,
         func: &gobject_ast::top_level::FunctionDefItem,
         file: &gobject_ast::FileModel,
         violations: &mut Vec<Violation>,
     ) {
         // Check for g_settings_set_value calls
         for call in func.find_calls(&["g_settings_set_value"]) {
-            self.check_settings_set_call(file, call, violations);
+            self.check_settings_set_call(config, file, call, violations);
         }
 
         // Check for g_variant_get_* calls
@@ -52,7 +52,7 @@ impl Rule for UseGSettingsTyped {
             "g_variant_get_double",
             "g_variant_get_strv",
         ]) {
-            self.check_variant_get_call(file, call, violations);
+            self.check_variant_get_call(config, file, call, violations);
         }
     }
 }
@@ -60,6 +60,7 @@ impl Rule for UseGSettingsTyped {
 impl UseGSettingsTyped {
     fn check_settings_set_call(
         &self,
+        config: &Config,
         file: &gobject_ast::FileModel,
         call: &CallExpression,
         violations: &mut Vec<Violation>,
@@ -96,14 +97,11 @@ impl UseGSettingsTyped {
         };
 
         // Build replacement
-        let replacement = if value_args.is_empty() {
-            format!("{} ({}, {})", typed_func, settings_arg, key_arg)
-        } else {
-            format!(
-                "{} ({}, {}, {})",
-                typed_func, settings_arg, key_arg, value_args
-            )
-        };
+        let mut args: Vec<&str> = vec![settings_arg, key_arg];
+        if !value_args.is_empty() {
+            args.push(&value_args);
+        }
+        let replacement = config.format_call(typed_func, &args);
         let message = format!(
             "Use {} instead of g_settings_set_value with g_variant_new for type safety",
             replacement
@@ -126,6 +124,7 @@ impl UseGSettingsTyped {
 
     fn check_variant_get_call(
         &self,
+        config: &Config,
         file: &gobject_ast::FileModel,
         call: &CallExpression,
         violations: &mut Vec<Violation>,
@@ -179,7 +178,7 @@ impl UseGSettingsTyped {
         };
 
         // Build replacement
-        let replacement = format!("{} ({}, {})", typed_func, settings_arg, key_arg);
+        let replacement = config.format_call(typed_func, &[settings_arg, key_arg]);
         let message = format!(
             "Use {} instead of g_variant_get_* with g_settings_get_value for type safety",
             replacement

--- a/src/rules/use_g_source_once.rs
+++ b/src/rules/use_g_source_once.rs
@@ -28,7 +28,7 @@ impl Rule for UseGSourceOnce {
     fn check_func_impl(
         &self,
         _ast_context: &AstContext,
-        _config: &Config,
+        config: &Config,
         func: &gobject_ast::top_level::FunctionDefItem,
         file: &gobject_ast::FileModel,
         violations: &mut Vec<Violation>,
@@ -54,7 +54,7 @@ impl Rule for UseGSourceOnce {
 
                         // Build arguments, replacing GSourceFunc cast with GSourceOnceFunc if
                         // present
-                        let args_str = call
+                        let args: Vec<String> = call
                             .arguments
                             .iter()
                             .enumerate()
@@ -74,14 +74,14 @@ impl Rule for UseGSourceOnce {
                                 }
                                 arg.to_source_string(&file.source).map(ToOwned::to_owned)
                             })
-                            .collect::<Vec<_>>()
-                            .join(", ");
+                            .collect();
+                        let arg_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
 
                         // Fix 1: Replace g_idle_add → g_idle_add_once
                         let mut fixes = vec![Fix::new(
                             call.location.start_byte,
                             call.location.end_byte,
-                            format!("{} ({})", replacement, args_str),
+                            config.format_call(replacement, &arg_refs),
                         )];
 
                         // Add callback fixes (return type + return statements)

--- a/src/rules/use_g_steal_pointer.rs
+++ b/src/rules/use_g_steal_pointer.rs
@@ -28,12 +28,12 @@ impl Rule for UseGStealPointer {
     fn check_func_impl(
         &self,
         _ast_context: &AstContext,
-        _config: &Config,
+        config: &Config,
         func: &gobject_ast::top_level::FunctionDefItem,
         file: &gobject_ast::FileModel,
         violations: &mut Vec<Violation>,
     ) {
-        self.check_function(func, file, violations);
+        self.check_function(func, config, file, violations);
     }
 }
 
@@ -41,25 +41,27 @@ impl UseGStealPointer {
     fn check_function(
         &self,
         func: &gobject_ast::top_level::FunctionDefItem,
+        config: &Config,
         file: &FileModel,
         violations: &mut Vec<Violation>,
     ) {
-        self.check_statements(&func.body_statements, file, violations);
+        self.check_statements(&func.body_statements, config, file, violations);
     }
 
     fn check_statements(
         &self,
         statements: &[Statement],
+        config: &Config,
         file: &FileModel,
         violations: &mut Vec<Violation>,
     ) {
         let mut i = 0;
         while i < statements.len() {
-            if self.try_if_else_steal(&statements[i], file, violations) {
+            if self.try_if_else_steal(&statements[i], config, file, violations) {
                 i += 1;
                 continue;
             }
-            if self.try_if_no_else_steal(&statements[i], file, violations) {
+            if self.try_if_no_else_steal(&statements[i], config, file, violations) {
                 i += 1;
                 continue;
             }
@@ -68,6 +70,7 @@ impl UseGStealPointer {
                     &statements[i],
                     &statements[i + 1],
                     &statements[i + 2],
+                    config,
                     file,
                     violations,
                 )
@@ -76,13 +79,19 @@ impl UseGStealPointer {
                 continue;
             }
             if i + 1 < statements.len()
-                && self.try_assign_null(&statements[i], &statements[i + 1], file, violations)
+                && self.try_assign_null(
+                    &statements[i],
+                    &statements[i + 1],
+                    config,
+                    file,
+                    violations,
+                )
             {
                 i += 2;
                 continue;
             }
             statements[i].for_each_child_block(|body| {
-                self.check_statements(body, file, violations);
+                self.check_statements(body, config, file, violations);
             });
             i += 1;
         }
@@ -94,6 +103,7 @@ impl UseGStealPointer {
         s1: &Statement,
         s2: &Statement,
         s3: &Statement,
+        config: &Config,
         file: &FileModel,
         violations: &mut Vec<Violation>,
     ) -> bool {
@@ -141,7 +151,9 @@ impl UseGStealPointer {
             return false;
         }
 
-        let replacement = format!("return g_steal_pointer (&{ptr_expr});");
+        let addr = format!("&{ptr_expr}");
+        let call = config.format_call("g_steal_pointer", &[&addr]);
+        let replacement = format!("return {call};");
         let message =
             format!("Use {replacement} instead of copying {ptr_expr} and setting it to NULL");
 
@@ -173,6 +185,7 @@ impl UseGStealPointer {
         &self,
         s1: &Statement,
         s2: &Statement,
+        config: &Config,
         file: &FileModel,
         violations: &mut Vec<Violation>,
     ) -> bool {
@@ -189,9 +202,10 @@ impl UseGStealPointer {
             return false;
         }
 
-        let replacement = format!("{other_expr} = g_steal_pointer (&{ptr_expr});");
-        let message =
-            format!("Use g_steal_pointer (&{ptr_expr}) instead of copying and setting to NULL");
+        let addr = format!("&{ptr_expr}");
+        let call = config.format_call("g_steal_pointer", &[&addr]);
+        let replacement = format!("{other_expr} = {call};");
+        let message = format!("Use {call} instead of copying and setting to NULL");
 
         // Use two separate fixes to preserve comments between statements
         let s2_end = s2.location().find_semicolon_end(&file.source);
@@ -216,6 +230,7 @@ impl UseGStealPointer {
     fn try_if_else_steal(
         &self,
         stmt: &Statement,
+        config: &Config,
         file: &FileModel,
         violations: &mut Vec<Violation>,
     ) -> bool {
@@ -265,9 +280,10 @@ impl UseGStealPointer {
             return false;
         }
 
-        let replacement = format!("{dest_expr} = g_steal_pointer (&{expr_text});");
-        let message =
-            format!("Use g_steal_pointer (&{expr_text}) instead of if/else copy-and-NULL pattern");
+        let addr = format!("&{expr_text}");
+        let call = config.format_call("g_steal_pointer", &[&addr]);
+        let replacement = format!("{dest_expr} = {call};");
+        let message = format!("Use {call} instead of if/else copy-and-NULL pattern");
         let fix = Fix::new(
             if_stmt.location.start_byte,
             if_stmt.location.end_byte,
@@ -289,6 +305,7 @@ impl UseGStealPointer {
     fn try_if_no_else_steal(
         &self,
         stmt: &Statement,
+        config: &Config,
         file: &FileModel,
 
         violations: &mut Vec<Violation>,
@@ -322,9 +339,10 @@ impl UseGStealPointer {
                 return false;
             }
 
-            let replacement = format!("{dest_expr} = g_steal_pointer (&{ptr_expr});");
-            let message =
-                format!("Use g_steal_pointer (&{ptr_expr}) instead of copying and setting to NULL");
+            let addr = format!("&{ptr_expr}");
+            let call = config.format_call("g_steal_pointer", &[&addr]);
+            let replacement = format!("{dest_expr} = {call};");
+            let message = format!("Use {call} instead of copying and setting to NULL");
 
             // If condition tests the same variable being stolen, remove entire if
             // Otherwise just replace the body
@@ -398,7 +416,9 @@ impl UseGStealPointer {
                 return false;
             }
 
-            let replacement = format!("return g_steal_pointer (&{ptr_expr});");
+            let addr = format!("&{ptr_expr}");
+            let call = config.format_call("g_steal_pointer", &[&addr]);
+            let replacement = format!("return {call};");
             let message =
                 format!("Use {replacement} instead of copying {ptr_expr} and setting it to NULL");
 

--- a/src/rules/use_g_str_has_prefix_suffix.rs
+++ b/src/rules/use_g_str_has_prefix_suffix.rs
@@ -28,7 +28,7 @@ impl Rule for UseGStrHasPrefixSuffix {
     fn check_func_impl(
         &self,
         _ast_context: &AstContext,
-        _config: &Config,
+        config: &Config,
         func: &gobject_ast::top_level::FunctionDefItem,
         file: &gobject_ast::FileModel,
         violations: &mut Vec<Violation>,
@@ -36,7 +36,7 @@ impl Rule for UseGStrHasPrefixSuffix {
         for stmt in &func.body_statements {
             stmt.walk_expressions(&mut |expr| {
                 expr.walk(&mut |e| {
-                    self.check_expression(e, file, violations);
+                    self.check_expression(e, config, file, violations);
                 });
             });
         }
@@ -47,6 +47,7 @@ impl UseGStrHasPrefixSuffix {
     fn check_expression(
         &self,
         expr: &Expression,
+        config: &Config,
         file: &gobject_ast::FileModel,
         violations: &mut Vec<Violation>,
     ) {
@@ -60,6 +61,7 @@ impl UseGStrHasPrefixSuffix {
             &bin.left,
             &bin.right,
             &bin.operator,
+            config,
             file,
             &bin.location,
             violations,
@@ -68,6 +70,7 @@ impl UseGStrHasPrefixSuffix {
             &bin.right,
             &bin.left,
             &bin.operator,
+            config,
             file,
             &bin.location,
             violations,
@@ -76,6 +79,7 @@ impl UseGStrHasPrefixSuffix {
             &bin.left,
             &bin.right,
             &bin.operator,
+            config,
             file,
             &bin.location,
             violations,
@@ -84,6 +88,7 @@ impl UseGStrHasPrefixSuffix {
             &bin.right,
             &bin.left,
             &bin.operator,
+            config,
             file,
             &bin.location,
             violations,
@@ -96,6 +101,7 @@ impl UseGStrHasPrefixSuffix {
         strncmp_side: &Expression,
         value_side: &Expression,
         operator: &BinaryOp,
+        config: &Config,
         file: &gobject_ast::FileModel,
         location: &gobject_ast::SourceLocation,
         violations: &mut Vec<Violation>,
@@ -134,10 +140,12 @@ impl UseGStrHasPrefixSuffix {
             .and_then(|e| e.to_source_string(&file.source))
             .unwrap_or_default();
 
+        let prefix_arg = format!("\"{}\"", prefix_text);
+        let call = config.format_call("g_str_has_prefix", &[str_arg_text, &prefix_arg]);
         let replacement = if *operator == BinaryOp::Equal {
-            format!("g_str_has_prefix ({str_arg_text}, \"{prefix_text}\")")
+            call
         } else {
-            format!("!g_str_has_prefix ({str_arg_text}, \"{prefix_text}\")")
+            format!("!{call}")
         };
         let message = format!(
             "Use {replacement} instead of strncmp() {} 0",
@@ -161,6 +169,7 @@ impl UseGStrHasPrefixSuffix {
         strcmp_side: &Expression,
         value_side: &Expression,
         operator: &BinaryOp,
+        config: &Config,
         file: &gobject_ast::FileModel,
         location: &gobject_ast::SourceLocation,
         violations: &mut Vec<Violation>,
@@ -196,10 +205,12 @@ impl UseGStrHasPrefixSuffix {
             return;
         };
 
+        let suffix_arg = format!("\"{}\"", suffix_text);
+        let call = config.format_call("g_str_has_suffix", &[str_expr, &suffix_arg]);
         let replacement = if *operator == BinaryOp::Equal {
-            format!("g_str_has_suffix ({str_expr}, \"{suffix_text}\")")
+            call
         } else {
-            format!("!g_str_has_suffix ({str_expr}, \"{suffix_text}\")")
+            format!("!{call}")
         };
         let message = format!(
             "Use {replacement} instead of strcmp() {} 0",

--- a/src/rules/use_g_string_free_and_steal.rs
+++ b/src/rules/use_g_string_free_and_steal.rs
@@ -28,13 +28,13 @@ impl Rule for UseGStringFreeAndSteal {
     fn check_func_impl(
         &self,
         _ast_context: &AstContext,
-        _config: &Config,
+        config: &Config,
         func: &gobject_ast::top_level::FunctionDefItem,
         file: &gobject_ast::FileModel,
         violations: &mut Vec<Violation>,
     ) {
         for call in func.find_calls(&["g_string_free"]) {
-            self.check_call(file, call, violations);
+            self.check_call(config, file, call, violations);
         }
     }
 }
@@ -42,6 +42,7 @@ impl Rule for UseGStringFreeAndSteal {
 impl UseGStringFreeAndSteal {
     fn check_call(
         &self,
+        config: &Config,
         file: &gobject_ast::FileModel,
         call: &gobject_ast::CallExpression,
         violations: &mut Vec<Violation>,
@@ -73,7 +74,7 @@ impl UseGStringFreeAndSteal {
         };
 
         // Build replacement
-        let replacement = format!("g_string_free_and_steal ({})", first_text);
+        let replacement = config.format_call("g_string_free_and_steal", &[first_text]);
         let message = format!(
             "Use {} instead of g_string_free({}, {}) for readability",
             replacement, first_text, second_text

--- a/src/rules/use_g_variant_new_typed.rs
+++ b/src/rules/use_g_variant_new_typed.rs
@@ -28,13 +28,13 @@ impl Rule for UseGVariantNewTyped {
     fn check_func_impl(
         &self,
         _ast_context: &AstContext,
-        _config: &Config,
+        config: &Config,
         func: &gobject_ast::top_level::FunctionDefItem,
         file: &gobject_ast::FileModel,
         violations: &mut Vec<Violation>,
     ) {
         for call in func.find_calls(&["g_variant_new"]) {
-            self.check_call(file, call, violations);
+            self.check_call(config, file, call, violations);
         }
     }
 }
@@ -42,6 +42,7 @@ impl Rule for UseGVariantNewTyped {
 impl UseGVariantNewTyped {
     fn check_call(
         &self,
+        config: &Config,
         file: &gobject_ast::FileModel,
         call: &gobject_ast::CallExpression,
         violations: &mut Vec<Violation>,
@@ -86,22 +87,13 @@ impl UseGVariantNewTyped {
         };
 
         // Collect remaining arguments (after format string)
-        let rest_args = if call.arguments.len() > 1 {
-            let rest: Vec<&str> = call.arguments[1..]
-                .iter()
-                .filter_map(|arg| arg.to_source_string(&file.source))
-                .collect();
-            rest.join(", ")
-        } else {
-            String::new()
-        };
+        let rest_args: Vec<&str> = call.arguments[1..]
+            .iter()
+            .filter_map(|arg| arg.to_source_string(&file.source))
+            .collect();
 
         // Build replacement
-        let replacement = if rest_args.is_empty() {
-            format!("{} ()", typed_func)
-        } else {
-            format!("{} ({})", typed_func, rest_args)
-        };
+        let replacement = config.format_call(typed_func, &rest_args);
 
         let message = format!(
             "Use {} instead of g_variant_new(\"{}\", ...) for type safety",

--- a/tests/fixtures/use_g_bytes_unref_to_data/basic.stderr
+++ b/tests/fixtures/use_g_bytes_unref_to_data/basic.stderr
@@ -1,3 +1,3 @@
-basic.c:10:3: use_g_bytes_unref_to_data: Use g_bytes_unref_to_data(bytes, &size) instead of g_bytes_get_data() followed by g_bytes_unref()
-basic.c:21:3: use_g_bytes_unref_to_data: Use g_bytes_unref_to_data(bytes, out_size) instead of g_bytes_get_data() followed by g_bytes_unref()
-basic.c:35:7: use_g_bytes_unref_to_data: Use g_bytes_unref_to_data(bytes, &size) instead of g_bytes_get_data() followed by g_bytes_unref()
+basic.c:10:3: use_g_bytes_unref_to_data: Use g_bytes_unref_to_data (bytes, &size) instead of g_bytes_get_data() followed by g_bytes_unref()
+basic.c:21:3: use_g_bytes_unref_to_data: Use g_bytes_unref_to_data (bytes, out_size) instead of g_bytes_get_data() followed by g_bytes_unref()
+basic.c:35:7: use_g_bytes_unref_to_data: Use g_bytes_unref_to_data (bytes, &size) instead of g_bytes_get_data() followed by g_bytes_unref()


### PR DESCRIPTION
Add a global config option to control whether replacement strings include a space before '(' (GLib coding style). Default is true for backward compatibility. Adds --no-space-before-paren CLI flag and Config helpers (paren_sep, format_call). All 16 rule files updated to use format_call for consistent formatting.