### PR TITLE
untranslated_string: Allow simple format strings

### DIFF
--- a/src/rules/untranslated_string.rs
+++ b/src/rules/untranslated_string.rs
@@ -71,6 +71,10 @@ impl UntranslatedString {
                 if !string_value.chars().any(char::is_alphabetic) {
                     return;
                 }
+                // Skip simple format strings like "%s" or "%d"
+                if matches!(string_value.as_bytes(), [b'%', c] if c.is_ascii_alphabetic()) {
+                    return;
+                }
             }
 
             let location = arg.location();

--- a/tests/fixtures/untranslated_string/format_strings.c
+++ b/tests/fixtures/untranslated_string/format_strings.c
@@ -1,0 +1,21 @@
+#include <gtk/gtk.h>
+
+#include <libintl.h>
+
+#define _(s) (s)
+
+void test_format_strings(void)
+{
+    // Should NOT be flagged - %s used to make next string not use printf
+    gtk_message_dialog_new (NULL, 0, GTK_MESSAGE_QUESTION, GTK_BUTTONS_OK,
+                            "%s", _("Some string"));
+
+    // Should be flagged - 1st string isn't just escape
+    gtk_message_dialog_new (NULL, 0, GTK_MESSAGE_QUESTION, GTK_BUTTONS_OK,
+                            "%d %d", 1234, 5678);
+
+    // Should NOT be flagged - 1st string is translated
+    gtk_message_dialog_new (NULL, 0, GTK_MESSAGE_QUESTION, GTK_BUTTONS_OK,
+                            _("%X"), 49374);
+}
+

--- a/tests/fixtures/untranslated_string/format_strings.stderr
+++ b/tests/fixtures/untranslated_string/format_strings.stderr
@@ -1,0 +1,1 @@
+format_strings.c:15:29: untranslated_string: User-visible string in gtk_message_dialog_new() should be wrapped with _("...")

--- a/tests/fixtures/untranslated_string/meson.build
+++ b/tests/fixtures/untranslated_string/meson.build
@@ -1,7 +1,7 @@
 sources = []
 
 if gtk4_dep.found()
-  sources += ['basic.c']
+  sources += ['basic.c', 'format_strings.c']
 endif
 
 if adwaita_dep.found()


### PR DESCRIPTION
These are intended to handle simple cases when translating isn't needed:

 * printing a number

 * using printf("%s", _("Translated")) to not require formatting in the string