### PR TITLE
missing_implementation: Don't check get_type() declarations

### DIFF
--- a/src/rules/missing_implementation.rs
+++ b/src/rules/missing_implementation.rs
@@ -24,13 +24,6 @@ impl Rule for MissingImplementation {
         _config: &Config,
         violations: &mut Vec<crate::rules::Violation>,
     ) {
-        let declared_types: HashSet<&str> = ast_context
-            .iter_header_files()
-            .flat_map(|(_, file)| file.iter_all_gobject_types())
-            .filter(|gt| gt.kind.is_declare())
-            .map(|gt| gt.type_name.as_str())
-            .collect();
-
         // Collect explicit function definitions and _get_type() names from
         // G_DEFINE_* macros that lack a matching G_DECLARE_*.
         let mut defined: HashSet<String> = HashSet::new();
@@ -39,7 +32,7 @@ impl Rule for MissingImplementation {
                 defined.insert(f.name.clone());
             }
             for gt in file.iter_all_gobject_types() {
-                if gt.kind.is_define() && !declared_types.contains(gt.type_name.as_str()) {
+                if gt.kind.is_define() {
                     defined.insert(format!("{}_get_type", gt.function_prefix));
                 }
             }

--- a/tests/fixtures/missing_implementation/gettype.c
+++ b/tests/fixtures/missing_implementation/gettype.c
@@ -1,0 +1,19 @@
+#include "gettype.h"
+
+G_DEFINE_TYPE (GtkMagic, gtk_magic, G_TYPE_OBJECT)
+
+static void
+gtk_magic_class_init (GtkMagicClass *class)
+{
+}
+
+static void
+gtk_magic_init (GtkMagic *self)
+{
+}
+
+GObject *
+gtk_magic_new (void)
+{
+  return g_object_new (GTK_TYPE_MAGIC, NULL);
+}

--- a/tests/fixtures/missing_implementation/gettype.h
+++ b/tests/fixtures/missing_implementation/gettype.h
@@ -1,0 +1,26 @@
+#include <glib-object.h>
+
+#define GTK_TYPE_MAGIC            (gtk_magic_get_type ())
+#define GTK_MAGIC(obj)            (G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_MAGIC, GtkMagic))
+#define GTK_MAGIC_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST ((klass), GTK_TYPE_MAGIC, GtkMagicClass))
+#define GTK_IS_MAGIC(obj)         (G_TYPE_CHECK_INSTANCE_TYPE ((obj), GTK_TYPE_MAGIC))
+#define GTK_IS_MAGIC_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE ((klass), GTK_TYPE_MAGIC))
+#define GTK_MAGIC_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS ((obj), GTK_TYPE_MAGIC, GtkMagicClass))
+
+
+typedef struct _GtkMagic         GtkMagic;
+typedef struct _GtkMagicClass    GtkMagicClass;
+
+struct _GtkMagic
+{
+  GObject parent_instance;
+};
+
+struct _GtkMagicClass
+{
+  GObjectClass parent_class;
+};
+
+GType    gtk_magic_get_type (void) G_GNUC_CONST;
+GObject *gtk_magic_new      (void);
+

--- a/tests/fixtures/missing_implementation/meson.build
+++ b/tests/fixtures/missing_implementation/meson.build
@@ -1,6 +1,8 @@
 sources = [
   'basic.c',
   'basic.h',
+  'gettype.c',
+  'gettype.h',
 ]
 
 foreach src : sources


### PR DESCRIPTION
It doesn't matter if and how a get_type() function was declared, it only matters if the function is implemented.

Besides, if the function wasn't declared, we wouldn't check if it's implemented in the first place.

Fixes regression introduced by manual gobject declaration parsing.

Fixes: 5e8b0ec85d89b3e27c8035c0399cbd08eb642b07