### PR TITLE
g_source_once: Accept int as well as gboolean

### DIFF
--- a/src/rules/use_g_source_once.rs
+++ b/src/rules/use_g_source_once.rs
@@ -191,7 +191,9 @@ impl UseGSourceOnce {
 
     fn fix_definition_return_type(&self, func: &FunctionDefItem) -> Option<Fix> {
         // Check if return type is gboolean
-        if func.return_type.as_basic() != Some(BasicType::Boolean) {
+        if func.return_type.as_basic() != Some(BasicType::Boolean)
+            && func.return_type.as_basic() != Some(BasicType::Int)
+        {
             return None;
         }
 
@@ -205,7 +207,9 @@ impl UseGSourceOnce {
 
     fn fix_declaration_return_type(&self, func: &FunctionDeclItem) -> Option<Fix> {
         // Check if return type is gboolean
-        if func.return_type.as_basic() != Some(BasicType::Boolean) {
+        if func.return_type.as_basic() != Some(BasicType::Boolean)
+            && func.return_type.as_basic() != Some(BasicType::Int)
+        {
             return None;
         }
 


### PR DESCRIPTION
... as the return value.

Some very old GTK2 code might still use that because it was how booleans were done before gboolean was established.

I encountered it once in GTK: https://gitlab.gnome.org/GNOME/gtk/-/blob/4.22.0/tests/testfiledialog.c#L196