### PR TITLE
use_clear_functions: Various improvements

### DIFF
--- a/src/rules/use_clear_functions.rs
+++ b/src/rules/use_clear_functions.rs
@@ -125,6 +125,18 @@ const CLEAR_MAPPINGS: &[ClearMapping] = &[
     PointerMapping!("g_variant_dict_unref"),
     PointerMapping!("g_variant_iter_unref"),
     PointerMapping!("g_variant_type_unref"),
+    PointerMapping!("gdk_color_state_unref"),
+    PointerMapping!("gdk_event_unref"),
+    PointerMapping!("gdk_texture_downloader_free"),
+    PointerMapping!("gsk_path_unref"),
+    PointerMapping!("gsk_path_builder_unref"),
+    PointerMapping!("gsk_path_measure_unref"),
+    PointerMapping!("gsk_render_node_unref"),
+    PointerMapping!("gsk_render_replay_free"),
+    PointerMapping!("gsk_stroke_free"),
+    PointerMapping!("gsk_transform_unref"),
+    PointerMapping!("gtk_expression_unref"),
+    PointerMapping!("gtk_expression_watch_unref"),
 ];
 
 impl ClearMapping {

--- a/src/rules/use_clear_functions.rs
+++ b/src/rules/use_clear_functions.rs
@@ -101,8 +101,23 @@ const CLEAR_MAPPINGS: &[ClearMapping] = &[
     PointerMapping!("g_hash_table_destroy"),
     PointerMapping!("g_hash_table_unref"),
     PointerMapping!("g_array_unref"),
+    PointerMapping!("g_async_queue_unref"),
+    PointerMapping!("g_byte_array_unref"),
     PointerMapping!("g_bytes_unref"),
+    PointerMapping!("g_checksum_free"),
+    PointerMapping!("g_date_free"),
+    PointerMapping!("g_date_time_unref"),
+    PointerMapping!("g_key_file_free"),
+    PointerMapping!("g_option_context_free"),
+    PointerMapping!("g_ptr_array_unref"),
+    PointerMapping!("g_queue_free"),
+    PointerMapping!("g_sequence_free"),
+    PointerMapping!("g_time_zone_unref"),
+    PointerMapping!("g_uri_unref"),
     PointerMapping!("g_variant_unref"),
+    PointerMapping!("g_variant_dict_unref"),
+    PointerMapping!("g_variant_iter_unref"),
+    PointerMapping!("g_variant_type_unref"),
 ];
 
 impl ClearMapping {

--- a/src/rules/use_clear_functions.rs
+++ b/src/rules/use_clear_functions.rs
@@ -44,6 +44,17 @@ struct ClearMapping {
     min_version: (u32, u32),
 }
 
+macro_rules! PointerMapping {
+    ($name:literal) => {
+        ClearMapping {
+            source_func: $name,
+            replacement: ClearReplacement::Pointer,
+            null_check: NullCheck::NullOrZero,
+            min_version: (2, 28),
+        }
+    }
+}
+
 const CLEAR_MAPPINGS: &[ClearMapping] = &[
     ClearMapping {
         source_func: "g_source_remove",
@@ -51,12 +62,7 @@ const CLEAR_MAPPINGS: &[ClearMapping] = &[
         null_check: NullCheck::Zero,
         min_version: (2, 56),
     },
-    ClearMapping {
-        source_func: "g_source_destroy",
-        replacement: ClearReplacement::Pointer,
-        null_check: NullCheck::NullOrZero,
-        min_version: (2, 28),
-    },
+    PointerMapping!("g_source_destroy"),
     ClearMapping {
         source_func: "g_signal_handler_disconnect",
         replacement: ClearReplacement::SignalHandler,
@@ -91,42 +97,12 @@ const CLEAR_MAPPINGS: &[ClearMapping] = &[
         null_check: NullCheck::NullOrZero,
         min_version: (2, 28),
     },
-    ClearMapping {
-        source_func: "g_free",
-        replacement: ClearReplacement::Pointer,
-        null_check: NullCheck::NullOrZero,
-        min_version: (2, 28),
-    },
-    ClearMapping {
-        source_func: "g_hash_table_unref",
-        replacement: ClearReplacement::Pointer,
-        null_check: NullCheck::NullOrZero,
-        min_version: (2, 28),
-    },
-    ClearMapping {
-        source_func: "g_hash_table_destroy",
-        replacement: ClearReplacement::Pointer,
-        null_check: NullCheck::NullOrZero,
-        min_version: (2, 28),
-    },
-    ClearMapping {
-        source_func: "g_array_unref",
-        replacement: ClearReplacement::Pointer,
-        null_check: NullCheck::NullOrZero,
-        min_version: (2, 28),
-    },
-    ClearMapping {
-        source_func: "g_bytes_unref",
-        replacement: ClearReplacement::Pointer,
-        null_check: NullCheck::NullOrZero,
-        min_version: (2, 28),
-    },
-    ClearMapping {
-        source_func: "g_variant_unref",
-        replacement: ClearReplacement::Pointer,
-        null_check: NullCheck::NullOrZero,
-        min_version: (2, 28),
-    },
+    PointerMapping!("g_free"),
+    PointerMapping!("g_hash_table_destroy"),
+    PointerMapping!("g_hash_table_unref"),
+    PointerMapping!("g_array_unref"),
+    PointerMapping!("g_bytes_unref"),
+    PointerMapping!("g_variant_unref"),
 ];
 
 impl ClearMapping {

--- a/src/rules/use_clear_functions.rs
+++ b/src/rules/use_clear_functions.rs
@@ -34,6 +34,7 @@ enum ClearReplacement {
     SignalHandler,
     WeakPointer,
     List { clear_func: &'static str },
+    Error,
 }
 
 #[derive(Clone, Copy)]
@@ -90,6 +91,12 @@ const CLEAR_MAPPINGS: &[ClearMapping] = &[
         },
         null_check: NullCheck::Null,
         min_version: (2, 64),
+    },
+    ClearMapping {
+        source_func: "g_error_free",
+        replacement: ClearReplacement::Error,
+        null_check: NullCheck::Null,
+        min_version: (2, 0),
     },
     ClearMapping {
         source_func: "g_object_unref",
@@ -163,6 +170,7 @@ fn format_replacement(
         ClearReplacement::List { clear_func } => {
             style.format_call_stmt(clear_func, &[&addr, "NULL"])
         }
+        ClearReplacement::Error => style.format_call_stmt("g_clear_error", &[&addr]),
     }
 }
 

--- a/src/rules/use_clear_functions.rs
+++ b/src/rules/use_clear_functions.rs
@@ -53,9 +53,9 @@ const CLEAR_MAPPINGS: &[ClearMapping] = &[
     },
     ClearMapping {
         source_func: "g_source_destroy",
-        replacement: ClearReplacement::HandleId,
-        null_check: NullCheck::Zero,
-        min_version: (2, 56),
+        replacement: ClearReplacement::Pointer,
+        null_check: NullCheck::NullOrZero,
+        min_version: (2, 28),
     },
     ClearMapping {
         source_func: "g_signal_handler_disconnect",

--- a/src/rules/use_clear_functions.rs
+++ b/src/rules/use_clear_functions.rs
@@ -1,6 +1,6 @@
 use gobject_ast::model::{
-    AssignmentOp, BinaryOp, Expression, FileModel, FunctionDefItem, IfStatement, SourceLocation,
-    Statement, UnaryOp,
+    AssignmentOp, BinaryExpression, BinaryOp, Expression, FileModel, FunctionDefItem, IfStatement,
+    SourceLocation, Statement, UnaryExpression, UnaryOp,
 };
 
 use crate::{
@@ -53,7 +53,7 @@ macro_rules! PointerMapping {
             null_check: NullCheck::NullOrZero,
             min_version: (2, 28),
         }
-    }
+    };
 }
 
 const CLEAR_MAPPINGS: &[ClearMapping] = &[
@@ -419,13 +419,27 @@ impl UseClearFunctions {
         }
 
         match expr {
-            Expression::Binary(bin) => {
-                if let Some(var) = self.find_variable_in_condition(&bin.left) {
-                    return Some(var);
+            Expression::Binary(BinaryExpression {
+                left: l,
+                operator: op,
+                right: r,
+                ..
+            }) => {
+                let l_empty = l.is_null() || l.is_zero();
+                let r_empty = r.is_null() || r.is_zero();
+                match (op, l_empty, r_empty) {
+                    (BinaryOp::NotEqual, true, false) => r.extract_variable_name(),
+                    (BinaryOp::Less, true, false) => r.extract_variable_name(),
+                    (BinaryOp::NotEqual, false, true) => l.extract_variable_name(),
+                    (BinaryOp::Greater, false, true) => l.extract_variable_name(),
+                    _ => None,
                 }
-                self.find_variable_in_condition(&bin.right)
             }
-            Expression::Unary(unary) => self.find_variable_in_condition(&unary.operand),
+            Expression::Unary(UnaryExpression {
+                operator: UnaryOp::Not,
+                operand: op,
+                ..
+            }) => op.extract_variable_name(),
             _ => expr.location().as_str(),
         }
     }

--- a/tests/fixtures/use_clear_functions/if_statements.c
+++ b/tests/fixtures/use_clear_functions/if_statements.c
@@ -1,0 +1,78 @@
+#include <glib.h>
+
+static void
+my_func (gpointer a, gpointer b, guint c)
+{
+  if (a != NULL)
+    {
+      g_free (a);
+      a = NULL;
+    }
+
+  if (NULL != a)
+    {
+      g_free (a);
+      a = NULL;
+    }
+
+  if (!a)
+    {
+      g_free (a);
+      a = NULL;
+    }
+
+  if (c > 0)
+    {
+      g_source_remove (c);
+      c = 0;
+    }
+
+  if (0 < c)
+    {
+      g_source_remove (c);
+      c = 0;
+    }
+
+  /* Variables don't match */
+  if (!b)
+    {
+      g_free (a);
+      a = NULL;
+    }
+
+  /* Not a simple NULL check */
+  if (a != b)
+    {
+      g_free (a);
+      a = NULL;
+    }
+
+  /* Not a check against zero */
+  if (c != 5)
+    {
+      g_source_remove (c);
+      c = 0;
+    }
+
+  /* Not a non-equal check */
+  if (a <= 0)
+    {
+      g_free (a);
+      a = NULL;
+    }
+
+  /* Not a NOT */
+  if (~c)
+    {
+      g_source_remove (c);
+      c = 0;
+    }
+
+  /* Not something we want to touch */
+  if ((a == b) == c)
+    {
+      g_free (a);
+      a = NULL;
+    }
+}
+

--- a/tests/fixtures/use_clear_functions/if_statements.fixed.c
+++ b/tests/fixtures/use_clear_functions/if_statements.fixed.c
@@ -1,0 +1,48 @@
+#include <glib.h>
+
+static void
+my_func (gpointer a, gpointer b, guint c)
+{
+  g_clear_pointer (&a, g_free);
+
+  g_clear_pointer (&a, g_free);
+
+  g_clear_pointer (&a, g_free);
+
+  g_clear_handle_id (&c, g_source_remove);
+
+  g_clear_handle_id (&c, g_source_remove);
+
+  /* Variables don't match */
+  if (!b)
+    {
+      g_clear_pointer (&a, g_free);
+    }
+
+  /* Not a simple NULL check */
+  if (a != b)
+    {
+      g_clear_pointer (&a, g_free);
+    }
+
+  /* Not a check against zero */
+  if (c != 5)
+    g_clear_handle_id (&c, g_source_remove);
+
+  /* Not a non-equal check */
+  if (a <= 0)
+    {
+      g_clear_pointer (&a, g_free);
+    }
+
+  /* Not a NOT */
+  if (~c)
+    g_clear_handle_id (&c, g_source_remove);
+
+  /* Not something we want to touch */
+  if ((a == b) == c)
+    {
+      g_clear_pointer (&a, g_free);
+    }
+}
+

--- a/tests/fixtures/use_clear_functions/if_statements.stderr
+++ b/tests/fixtures/use_clear_functions/if_statements.stderr
@@ -1,0 +1,11 @@
+if_statements.c:6:3: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of manual NULL check, unref, and assignment
+if_statements.c:12:3: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of manual NULL check, unref, and assignment
+if_statements.c:18:3: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of manual NULL check, unref, and assignment
+if_statements.c:26:7: use_clear_functions: Use g_clear_handle_id (&c, g_source_remove) instead of g_source_remove and zero assignment
+if_statements.c:32:7: use_clear_functions: Use g_clear_handle_id (&c, g_source_remove) instead of g_source_remove and zero assignment
+if_statements.c:39:7: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of g_free and NULL/zero assignment
+if_statements.c:46:7: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of g_free and NULL/zero assignment
+if_statements.c:53:7: use_clear_functions: Use g_clear_handle_id (&c, g_source_remove) instead of g_source_remove and zero assignment
+if_statements.c:60:7: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of g_free and NULL/zero assignment
+if_statements.c:67:7: use_clear_functions: Use g_clear_handle_id (&c, g_source_remove) instead of g_source_remove and zero assignment
+if_statements.c:74:7: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of g_free and NULL/zero assignment

--- a/tests/fixtures/use_clear_functions/meson.build
+++ b/tests/fixtures/use_clear_functions/meson.build
@@ -8,6 +8,8 @@ sources = [
   'handle_id_issue_25.fixed.c',
   'handle_id_multi_stmt.c',
   'handle_id_multi_stmt.fixed.c',
+  'if_statements.c',
+  'if_statements.fixed.c',
   'list_basic.c',
   'list_basic.fixed.c',
   'signal_handler_basic.c',


### PR DESCRIPTION
I tried to fix GTK's code to use clear functions, which claimed 319 violations. It then got some of them wrong and missed others, so I spent some time improving the rule.

It now fixes things properly, see https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/9949

The only thing I had to do manually is fix `guint` vs `gulong` vs `glong` variable types which were common mixups. The clear functions check the type is correct, the manual fixage doesn't.