### PR TITLE
Do not read ignore files from parent directories

### DIFF
--- a/src/ast_context.rs
+++ b/src/ast_context.rs
@@ -42,6 +42,7 @@ impl AstContext {
             .git_global(true) // Respect global gitignore
             .git_exclude(true) // Respect .git/info/exclude
             .require_git(false) // Work in non-git directories too
+            .parents(false)
             .build()
             .filter_map(std::result::Result::ok)
             .filter(|e| {


### PR DESCRIPTION
I ran gobject-linter on a local project checkout and it did not find any files to check. The reason turned out to be a `.gitignore` file on my homedir with a `*` directive.

I don't think there is a good reason to read ignore files from the parents of a project dir and fortunately the `ignore` crate has an [option](https://docs.rs/ignore/latest/ignore/struct.WalkBuilder.html#method.parents) to disable it. This PR enables this option.