### PR TITLE
Use extract_null_check_variable() instead of its _name() variant

### DIFF
--- a/gobject-ast/src/model/expression/mod.rs
+++ b/gobject-ast/src/model/expression/mod.rs
@@ -69,6 +69,7 @@ impl PartialEq for Expression {
         match self {
             Self::Identifier(s) => matches!(other, Self::Identifier(o) if s == o),
             Self::FieldAccess(s) => matches!(other, Self::FieldAccess(o) if s == o),
+            Self::Unary(s) => matches!(other, Self::Unary(o) if s == o),
             _ => false,
         }
     }
@@ -194,6 +195,12 @@ impl Expression {
     pub fn extract_variable(&self) -> Option<&Self> {
         match self {
             Self::Identifier(_) | Self::FieldAccess(_) => Some(self),
+            // We're probably only interested in AddressOf and Dereference, which act on pointers.
+            // Not should probably be treated separately, since it behaves like a binary operator
+            // on a pointer, i.e., !p <=> p == NULL.
+            Self::Unary(u) if matches!(u.operator, UnaryOp::AddressOf | UnaryOp::Dereference) => {
+                Some(self)
+            }
             _ => None,
         }
     }

--- a/gobject-ast/src/model/expression/unary.rs
+++ b/gobject-ast/src/model/expression/unary.rs
@@ -8,3 +8,9 @@ pub struct UnaryExpression {
     pub operand: Box<Expression>,
     pub location: SourceLocation,
 }
+
+impl PartialEq for UnaryExpression {
+    fn eq(&self, other: &Self) -> bool {
+        self.operator == other.operator && self.operand == other.operand
+    }
+}

--- a/gobject-ast/src/model/statement/if_stmt.rs
+++ b/gobject-ast/src/model/statement/if_stmt.rs
@@ -24,13 +24,6 @@ impl IfStatement {
         }
     }
 
-    /// Extract variable name from NULL check patterns: (ptr != NULL), (NULL != ptr),
-    /// (ptr)
-    pub fn extract_null_check_variable_name(&self) -> Option<&str> {
-        self.extract_null_check_variable()
-            .and_then(|v| v.location().as_str())
-    }
-
     /// Extract variable from non-zero check patterns: (id > 0), (id != 0),
     /// (id), (self->id)
     pub fn extract_nonzero_check_variable(&self) -> Option<&str> {

--- a/gobject-ast/src/model/statement/mod.rs
+++ b/gobject-ast/src/model/statement/mod.rs
@@ -341,15 +341,14 @@ impl Statement {
 
     /// Check if this statement assigns a value matching the predicate to the
     /// target variable (unwraps labels)
-    pub fn is_assignment_to<F>(&self, target_var: &str, value_check: F) -> bool
+    pub fn is_assignment_to<F>(&self, target_var: &Expression, value_check: F) -> bool
     where
         F: Fn(&Expression) -> bool,
     {
         if let Self::Expression(expr_stmt) = self.inner_statement()
             && let Expression::Assignment(assign) = expr_stmt.as_ref()
         {
-            let lhs_text = assign.lhs.location().as_str().unwrap_or("");
-            return lhs_text.trim() == target_var.trim() && value_check(&assign.rhs);
+            return assign.lhs.as_ref() == target_var && value_check(&assign.rhs);
         }
         false
     }
@@ -366,8 +365,8 @@ impl Statement {
     }
 
     /// Check if this statement assigns NULL to the target variable
-    pub fn is_null_assignment_to(&self, var_name: &str) -> bool {
-        self.is_assignment_to(var_name, Expression::is_null)
+    pub fn is_null_assignment_to(&self, var: &Expression) -> bool {
+        self.is_assignment_to(var, Expression::is_null)
     }
 
     fn non_comments(stmts: &[Self]) -> Vec<&Self> {

--- a/gobject-ast/src/model/statement/variable_decl.rs
+++ b/gobject-ast/src/model/statement/variable_decl.rs
@@ -1,6 +1,6 @@
 use serde::Serialize;
 
-use crate::model::{Expression, SourceLocation, TypeInfo};
+use crate::model::{Expression, IdentifierExpression, SourceLocation, TypeInfo};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct VariableDecl {
@@ -24,5 +24,12 @@ impl VariableDecl {
     /// obj->field)
     pub fn is_simple_identifier(&self) -> bool {
         !self.name.contains("->") && !self.name.contains('.')
+    }
+
+    pub fn as_expression(&self) -> Expression {
+        Expression::Identifier(IdentifierExpression {
+            name: self.name.clone(),
+            location: self.name_location.clone(),
+        })
     }
 }

--- a/src/rules/g_error_init.rs
+++ b/src/rules/g_error_init.rs
@@ -70,7 +70,7 @@ impl GErrorInit {
             return;
         }
 
-        if self.first_use_is_assignment(&decl.name, following) {
+        if self.first_use_is_assignment(decl, following) {
             return;
         }
 
@@ -86,18 +86,18 @@ impl GErrorInit {
         ));
     }
 
-    fn first_use_is_assignment(&self, var: &str, stmts: &[Statement]) -> bool {
+    fn first_use_is_assignment(&self, decl: &VariableDecl, stmts: &[Statement]) -> bool {
         for stmt in stmts {
             let mut references_var = false;
             stmt.visit_expressions(&mut |expr| {
-                if expr.contains_identifier(var) {
+                if expr.contains_identifier(&decl.name) {
                     references_var = true;
                 }
             });
             if !references_var {
                 continue;
             }
-            return stmt.is_assignment_to(var, |_| true);
+            return stmt.is_assignment_to(&decl.as_expression(), |_| true);
         }
         true
     }

--- a/src/rules/use_clear_functions.rs
+++ b/src/rules/use_clear_functions.rs
@@ -399,17 +399,18 @@ impl UseClearFunctions {
                 continue;
             }
 
-            let var_name = match mapping.replacement {
+            let var = match mapping.replacement {
                 ClearReplacement::WeakPointer => {
                     self.extract_weak_pointer_var(call.arguments.get(1)?)?
                 }
-                _ => call.get_arg(0)?.location().as_str()?,
+                _ => call.get_arg(0)?,
             };
 
-            if !stmt2.is_assignment_to(var_name, |expr| mapping.null_check.matches(expr)) {
+            if !stmt2.is_assignment_to(var, |expr| mapping.null_check.matches(expr)) {
                 continue;
             }
 
+            let var_name = var.location().as_str().unwrap_or_default();
             let extra_arg = call.get_arg_text(1);
             let replacement = format_replacement(mapping, var_name, extra_arg, &config.style);
             let message = format!(
@@ -473,6 +474,7 @@ impl UseClearFunctions {
             return false;
         }
 
+        let checked_var = checked_var.location().as_str().unwrap_or_default();
         let replacement = format_replacement(&mapping, checked_var, extra_arg, &config.style);
         let message = format!(
             "Use {} instead of manual {} check, {}, and {} assignment",
@@ -493,8 +495,11 @@ impl UseClearFunctions {
         true
     }
 
-    fn find_variable_in_condition<'a>(&self, expr: &'a Expression) -> Option<(&'a str, NullCheck)> {
-        if let Some(var) = expr.extract_variable_name() {
+    fn find_variable_in_condition<'a>(
+        &self,
+        expr: &'a Expression,
+    ) -> Option<(&'a Expression, NullCheck)> {
+        if let Some(var) = expr.extract_variable() {
             return Some((var, NullCheck::NullOrZero));
         }
 
@@ -511,30 +516,30 @@ impl UseClearFunctions {
                 let r_neg1 = r.is_negative_one();
                 match (op, l_empty, r_empty, l_neg1, r_neg1) {
                     (BinaryOp::NotEqual, true, false, ..) => {
-                        Some((r.extract_variable_name()?, NullCheck::NullOrZero))
+                        Some((r.extract_variable()?, NullCheck::NullOrZero))
                     }
                     (BinaryOp::Less, true, false, ..) => {
-                        Some((r.extract_variable_name()?, NullCheck::NullOrZero))
+                        Some((r.extract_variable()?, NullCheck::NullOrZero))
                     }
                     (BinaryOp::NotEqual, false, true, ..) => {
-                        Some((l.extract_variable_name()?, NullCheck::NullOrZero))
+                        Some((l.extract_variable()?, NullCheck::NullOrZero))
                     }
                     (BinaryOp::Greater, false, true, ..) => {
-                        Some((l.extract_variable_name()?, NullCheck::NullOrZero))
+                        Some((l.extract_variable()?, NullCheck::NullOrZero))
                     }
                     // fd >= 0 or 0 <= fd
                     (BinaryOp::GreaterEqual, false, ..) if r_empty => {
-                        Some((l.extract_variable_name()?, NullCheck::NegativeOne))
+                        Some((l.extract_variable()?, NullCheck::NegativeOne))
                     }
                     (BinaryOp::LessEqual, _, false, ..) if l_empty => {
-                        Some((r.extract_variable_name()?, NullCheck::NegativeOne))
+                        Some((r.extract_variable()?, NullCheck::NegativeOne))
                     }
                     // fd != -1 or -1 != fd
                     (BinaryOp::NotEqual, _, _, _, true) => {
-                        Some((l.extract_variable_name()?, NullCheck::NegativeOne))
+                        Some((l.extract_variable()?, NullCheck::NegativeOne))
                     }
                     (BinaryOp::NotEqual, _, _, true, _) => {
-                        Some((r.extract_variable_name()?, NullCheck::NegativeOne))
+                        Some((r.extract_variable()?, NullCheck::NegativeOne))
                     }
                     _ => None,
                 }
@@ -543,8 +548,8 @@ impl UseClearFunctions {
                 operator: UnaryOp::Not,
                 operand: op,
                 ..
-            }) => Some((op.extract_variable_name()?, NullCheck::NullOrZero)),
-            _ => Some((expr.location().as_str()?, NullCheck::NullOrZero)),
+            }) => Some((op.extract_variable()?, NullCheck::NullOrZero)),
+            _ => Some((expr, NullCheck::NullOrZero)),
         }
     }
 
@@ -563,7 +568,7 @@ impl UseClearFunctions {
     fn find_unref_in_body<'a>(
         &self,
         statements: &'a [Statement],
-        var_name: &str,
+        var: &Expression,
         config: &Config,
     ) -> Option<(ClearMapping, Option<&'a str>)> {
         for stmt in statements {
@@ -583,9 +588,7 @@ impl UseClearFunctions {
                     }
                     if call.is_function(mapping.source_func) {
                         for arg in &call.arguments {
-                            if let Some(arg_text) = arg.location().as_str()
-                                && arg_text == var_name
-                            {
+                            if arg.as_ref() == var {
                                 let extra = call.get_arg(1).and_then(|a| a.location().as_str());
                                 return Some((*mapping, extra));
                             }
@@ -600,12 +603,12 @@ impl UseClearFunctions {
     fn has_null_assignment(
         &self,
         statements: &[Statement],
-        var_name: &str,
+        var: &Expression,
         null_check: NullCheck,
     ) -> bool {
         statements
             .iter()
-            .any(|stmt| stmt.is_assignment_to(var_name, |expr| null_check.matches(expr)))
+            .any(|stmt| stmt.is_assignment_to(var, |expr| null_check.matches(expr)))
     }
 
     fn try_handle_id_if_pattern(
@@ -674,11 +677,11 @@ impl UseClearFunctions {
         let mut results = Vec::new();
 
         Statement::for_each_pair(statements, |first, second| {
-            if let Some((var_name, mapping)) = self.extract_handle_cleanup(first, config)
-                && second.is_assignment_to(&var_name, Expression::is_zero)
+            if let Some((var, mapping)) = self.extract_handle_cleanup(first, config)
+                && second.is_assignment_to(var, Expression::is_zero)
             {
                 results.push((
-                    var_name,
+                    var.location().as_str().unwrap_or_default().to_owned(),
                     mapping,
                     first.inner_statement().location().clone(),
                     second.inner_statement().location().clone(),
@@ -689,11 +692,11 @@ impl UseClearFunctions {
         results
     }
 
-    fn extract_handle_cleanup(
+    fn extract_handle_cleanup<'a>(
         &self,
-        stmt: &Statement,
+        stmt: &'a Statement,
         config: &Config,
-    ) -> Option<(String, ClearMapping)> {
+    ) -> Option<(&'a Expression, ClearMapping)> {
         let call = stmt.extract_call()?;
         let func_name = call.function_name_str()?;
 
@@ -703,10 +706,7 @@ impl UseClearFunctions {
                 && m.is_enabled(config)
         })?;
 
-        let arg_expr = call.get_arg(0)?;
-        let var_name = arg_expr.location().as_str()?.trim().to_owned();
-
-        Some((var_name, *mapping))
+        Some((call.get_arg(0)?, *mapping))
     }
 
     fn check_unnecessary_braces(
@@ -959,7 +959,7 @@ impl UseClearFunctions {
         found
     }
 
-    fn extract_weak_pointer_var<'a>(&self, expr: &'a Expression) -> Option<&'a str> {
+    fn extract_weak_pointer_var<'a>(&self, expr: &'a Expression) -> Option<&'a Expression> {
         // Handle cast expressions: (gpointer*)&var
         let inner_expr = match expr {
             Expression::Cast(cast) => &*cast.operand,
@@ -969,7 +969,7 @@ impl UseClearFunctions {
         if let Expression::Unary(unary) = inner_expr
             && unary.operator == UnaryOp::AddressOf
         {
-            return unary.operand.extract_variable_name();
+            return unary.operand.extract_variable();
         }
 
         None

--- a/src/rules/use_g_steal_pointer.rs
+++ b/src/rules/use_g_steal_pointer.rs
@@ -1,4 +1,6 @@
-use gobject_ast::model::{AssignmentOp, Expression, FileModel, FunctionDefItem, Statement};
+use gobject_ast::model::{
+    AssignmentOp, Expression, FileModel, FunctionDefItem, Statement, UnaryOp,
+};
 
 use crate::{
     ast_context::AstContext,
@@ -106,12 +108,12 @@ impl UseGStealPointer {
         }
 
         // Get the variable name from the initializer
-        let Some(ptr_expr) = init_expr.extract_variable_name() else {
+        let Some(ptr_expr) = init_expr.extract_variable() else {
             return false;
         };
 
         // Skip dereferences
-        if ptr_expr.starts_with('*') {
+        if matches!(ptr_expr, Expression::Unary(u) if u.operator == UnaryOp::Dereference) {
             return false;
         }
 
@@ -135,6 +137,7 @@ impl UseGStealPointer {
             return false;
         }
 
+        let ptr_expr = ptr_expr.location().as_str().unwrap_or_default();
         let steal = style.format_addr_call("g_steal_pointer", ptr_expr, &[]);
         let replacement = format!("return {steal};");
         let message =
@@ -167,7 +170,7 @@ impl UseGStealPointer {
             return false;
         };
 
-        if ptr_expr.starts_with('*') {
+        if matches!(ptr_expr, Expression::Unary(u) if u.operator == UnaryOp::Dereference) {
             return false;
         }
 
@@ -175,6 +178,8 @@ impl UseGStealPointer {
             return false;
         }
 
+        let other_expr = other_expr.location().as_str().unwrap_or_default();
+        let ptr_expr = ptr_expr.location().as_str().unwrap_or_default();
         let steal = style.format_addr_call("g_steal_pointer", ptr_expr, &[]);
         let replacement = format!("{other_expr} = {steal};");
         let message = format!("Use {steal} instead of copying and setting to NULL");
@@ -208,12 +213,12 @@ impl UseGStealPointer {
         };
 
         // Extract tested expression from condition
-        let Some(expr_text) = if_stmt.extract_null_check_variable_name() else {
+        let Some(expr) = if_stmt.extract_null_check_variable() else {
             return false;
         };
 
         // Skip dereference expressions
-        if expr_text.starts_with('*') {
+        if matches!(expr, Expression::Unary(u) if u.operator == UnaryOp::Dereference) {
             return false;
         }
 
@@ -226,12 +231,12 @@ impl UseGStealPointer {
         let Some((dest_expr, rhs)) = self.extract_assignment(&if_stmt.then_body[0]) else {
             return false;
         };
-        if rhs != expr_text {
+        if rhs != expr {
             return false;
         }
 
         // then_body[1]: expr = NULL
-        if !if_stmt.then_body[1].is_null_assignment_to(expr_text) {
+        if !if_stmt.then_body[1].is_null_assignment_to(expr) {
             return false;
         }
 
@@ -243,7 +248,9 @@ impl UseGStealPointer {
             return false;
         }
 
-        let steal = style.format_addr_call("g_steal_pointer", expr_text, &[]);
+        let expr = expr.location().as_str().unwrap_or_default();
+        let dest_expr = dest_expr.location().as_str().unwrap_or_default();
+        let steal = style.format_addr_call("g_steal_pointer", expr, &[]);
         let replacement = format!("{dest_expr} = {steal};");
         let message = format!("Use {steal} instead of if/else copy-and-NULL pattern");
         let fix = Fix::new(
@@ -275,7 +282,7 @@ impl UseGStealPointer {
         }
 
         // Try to extract condition expression
-        let condition_expr = if_stmt.extract_null_check_variable_name();
+        let condition_expr = if_stmt.extract_null_check_variable();
 
         // Pattern 1: 2 statements - dest = ptr; ptr = NULL;
         if if_stmt.then_body.len() == 2 {
@@ -284,7 +291,7 @@ impl UseGStealPointer {
             };
 
             // Skip dereference expressions
-            if ptr_expr.starts_with('*') {
+            if matches!(ptr_expr, Expression::Unary(u) if u.operator == UnaryOp::Dereference) {
                 return false;
             }
 
@@ -292,7 +299,9 @@ impl UseGStealPointer {
                 return false;
             }
 
-            let steal = style.format_addr_call("g_steal_pointer", ptr_expr, &[]);
+            let dest_expr = dest_expr.location().as_str().unwrap_or_default();
+            let ptr_expr_str = ptr_expr.location().as_str().unwrap_or_default();
+            let steal = style.format_addr_call("g_steal_pointer", ptr_expr_str, &[]);
             let replacement = format!("{dest_expr} = {steal};");
             let message = format!("Use {steal} instead of copying and setting to NULL");
 
@@ -338,12 +347,12 @@ impl UseGStealPointer {
                 return false;
             }
 
-            let Some(ptr_expr) = init_expr.extract_variable_name() else {
+            let Some(ptr_expr) = init_expr.extract_variable() else {
                 return false;
             };
 
             // Skip dereference expressions
-            if ptr_expr.starts_with('*') {
+            if matches!(ptr_expr, Expression::Unary(u) if u.operator == UnaryOp::Dereference) {
                 return false;
             }
 
@@ -366,10 +375,12 @@ impl UseGStealPointer {
                 return false;
             }
 
-            let steal = style.format_addr_call("g_steal_pointer", ptr_expr, &[]);
+            let ptr_expr_str = ptr_expr.location().as_str().unwrap_or_default();
+            let steal = style.format_addr_call("g_steal_pointer", ptr_expr_str, &[]);
             let replacement = format!("return {steal};");
-            let message =
-                format!("Use {replacement} instead of copying {ptr_expr} and setting it to NULL");
+            let message = format!(
+                "Use {replacement} instead of copying {ptr_expr_str} and setting it to NULL"
+            );
 
             // If condition tests the same variable being stolen, remove entire if
             let fix = if condition_expr == Some(ptr_expr) {
@@ -401,7 +412,10 @@ impl UseGStealPointer {
     }
 
     /// Extract (lhs, rhs) from assignment statement
-    fn extract_assignment<'a>(&self, stmt: &'a Statement) -> Option<(&'a str, &'a str)> {
+    fn extract_assignment<'a>(
+        &self,
+        stmt: &'a Statement,
+    ) -> Option<(&'a Expression, &'a Expression)> {
         let Statement::Expression(expr_stmt) = stmt.inner_statement() else {
             return None;
         };
@@ -414,10 +428,9 @@ impl UseGStealPointer {
             return None;
         }
 
-        // Get rhs as string - handle various expression types
+        // Get rhs - handle various expression types
         let rhs = match &*assign.rhs {
-            Expression::Identifier(id) => id.name.as_str(),
-            Expression::FieldAccess(f) => f.location.as_str().unwrap_or(""),
+            Expression::Identifier(_) | Expression::FieldAccess(_) => &assign.rhs,
             Expression::Null(_) | Expression::Call(_) => {
                 // For NULL or function calls like g_strdup(), we don't want to suggest
                 // g_steal_pointer
@@ -428,10 +441,9 @@ impl UseGStealPointer {
             }
         };
 
-        let lhs = assign.lhs_as_text();
-        if lhs.is_empty() {
+        if assign.lhs_as_text().is_empty() {
             return None;
         }
-        Some((lhs, rhs))
+        Some((&assign.lhs, rhs))
     }
 }

--- a/tests/fixtures/unnecessary_null_check/basic.c
+++ b/tests/fixtures/unnecessary_null_check/basic.c
@@ -20,4 +20,7 @@ my_func (char *str, char *other, char *ptr, char **strv, GList *list)
 
   if (list->data != NULL)
     g_free (list->data);
+
+  if (*strv != NULL)
+    g_free (*strv);
 }

--- a/tests/fixtures/unnecessary_null_check/basic.fixed.c
+++ b/tests/fixtures/unnecessary_null_check/basic.fixed.c
@@ -14,4 +14,6 @@ my_func (char *str, char *other, char *ptr, char **strv, GList *list)
   g_free_size (other, 128);
 
   g_free (list->data);
+
+  g_free (*strv);
 }

--- a/tests/fixtures/unnecessary_null_check/basic.stderr
+++ b/tests/fixtures/unnecessary_null_check/basic.stderr
@@ -4,3 +4,4 @@ basic.c:12:3: unnecessary_null_check: Remove unnecessary NULL check before g_fre
 basic.c:15:3: unnecessary_null_check: Remove unnecessary NULL check before g_strfreev (g_strfreev handles NULL)
 basic.c:18:3: unnecessary_null_check: Remove unnecessary NULL check before g_free_size (g_free_size handles NULL)
 basic.c:21:3: unnecessary_null_check: Remove unnecessary NULL check before g_free (g_free handles NULL)
+basic.c:24:3: unnecessary_null_check: Remove unnecessary NULL check before g_free (g_free handles NULL)


### PR DESCRIPTION
First round of refactoring aimed at using expression comparisons instead
of string comparisons. I've kept the commit size as small as possible,
but simply removing extract_null_check_variable_name() already has quite
a few consequences.