### PR TITLE
use_clear_functions: Fix freed condition for g_clear_signal_handler

### DIFF
--- a/src/rules/use_clear_functions.rs
+++ b/src/rules/use_clear_functions.rs
@@ -865,7 +865,7 @@ impl UseClearFunctions {
             return false;
         }
 
-        if self.is_freed_in_stmts(all_stmts, base) || self.is_freed_in_stmts(all_stmts, obj) {
+        if self.is_freed_in_stmts(all_stmts, base) {
             return false;
         }
 

--- a/tests/fixtures/use_clear_functions/signal_handler_basic.c
+++ b/tests/fixtures/use_clear_functions/signal_handler_basic.c
@@ -79,13 +79,13 @@ clear_bare_member_freed (MyObj *self)
   g_free (self);
 }
 
-/* bare disconnect on struct member, but the source is g_clear_object'd — skip */
+/* bare disconnect on struct member, but the struct is g_clear_object'd — skip */
 
 static void
 clear_bare_member_source_cleared (MyObj *self)
 {
   g_signal_handler_disconnect (self->source, self->signal_id);
-  g_clear_object (&self->source);
+  g_clear_object (&self);
 }
 
 /* bare disconnect, but the struct is freed under a label — skip */

--- a/tests/fixtures/use_clear_functions/signal_handler_basic.fixed.c
+++ b/tests/fixtures/use_clear_functions/signal_handler_basic.fixed.c
@@ -64,13 +64,13 @@ clear_bare_member_freed (MyObj *self)
   g_free (self);
 }
 
-/* bare disconnect on struct member, but the source is g_clear_object'd — skip */
+/* bare disconnect on struct member, but the struct is g_clear_object'd — skip */
 
 static void
 clear_bare_member_source_cleared (MyObj *self)
 {
   g_signal_handler_disconnect (self->source, self->signal_id);
-  g_clear_object (&self->source);
+  g_clear_object (&self);
 }
 
 /* bare disconnect, but the struct is freed under a label — skip */


### PR DESCRIPTION
Unless I'm missing something, there's no reason to be concerned with the object emitting the signal; it has nothing to do with the fact that the handler ID needs to be reset.