### PR TITLE
Replace various string comparisons with expression comparisons

### DIFF
--- a/src/rules/use_g_set_object.rs
+++ b/src/rules/use_g_set_object.rs
@@ -55,7 +55,7 @@ impl UseGSetObject {
         violations: &mut Vec<Violation>,
     ) -> bool {
         // First statement: g_clear_object(&var) or g_object_unref(var)
-        let Some((var_name, needs_deref)) = self.extract_clear_or_unref_var(s1) else {
+        let Some((var, needs_deref)) = self.extract_clear_or_unref_var(s1) else {
             return false;
         };
 
@@ -65,11 +65,9 @@ impl UseGSetObject {
         };
 
         let matches = if needs_deref {
-            assign_var.len() == var_name.len() + 1
-                && assign_var.starts_with('*')
-                && assign_var[1..] == *var_name
+            matches!(assign_var, Expression::Unary(u) if u.operator == UnaryOp::Dereference && u.operand.as_ref() == var)
         } else {
-            assign_var == var_name
+            assign_var == var
         };
         if !matches {
             return false;
@@ -78,6 +76,7 @@ impl UseGSetObject {
         // g_set_object takes GObject**, so:
         // - If var is GObject* (needs_deref=false), use &var
         // - If var is GObject** (needs_deref=true), use var directly
+        let var_name = var.location().as_str().unwrap_or_default();
         let replacement = if needs_deref {
             config
                 .style
@@ -105,7 +104,10 @@ impl UseGSetObject {
     /// Extract variable from g_clear_object(&var)/g_clear_object(ptr) or
     /// g_object_unref(var) Returns (var_name, needs_deref) where
     /// needs_deref indicates if assignment should use *var
-    fn extract_clear_or_unref_var<'a>(&self, stmt: &'a Statement) -> Option<(&'a str, bool)> {
+    fn extract_clear_or_unref_var<'a>(
+        &self,
+        stmt: &'a Statement,
+    ) -> Option<(&'a Expression, bool)> {
         let Statement::Expression(expr_stmt) = stmt else {
             return None;
         };
@@ -127,22 +129,25 @@ impl UseGSetObject {
                 && unary.operator == UnaryOp::AddressOf
             {
                 // Case 1: g_clear_object(&var)
-                return Some((unary.operand.location().as_str()?, false));
+                return Some((&unary.operand, false));
             } else {
                 // Case 2: g_clear_object(ptr) where ptr is GObject**
-                return Some((first_arg.location().as_str()?, true));
+                return Some((first_arg, true));
             }
         } else if call.is_function("g_object_unref") {
             // g_object_unref(var) - assignment is var = ...
             let first_arg = call.get_arg(0)?;
-            return Some((first_arg.location().as_str()?, false));
+            return Some((first_arg, false));
         }
 
         None
     }
 
     /// Extract (var, new_val) from var = g_object_ref(new_val)
-    fn extract_object_ref_assignment<'a>(&self, stmt: &'a Statement) -> Option<(&'a str, &'a str)> {
+    fn extract_object_ref_assignment<'a>(
+        &self,
+        stmt: &'a Statement,
+    ) -> Option<(&'a Expression, &'a str)> {
         let Statement::Expression(expr_stmt) = stmt else {
             return None;
         };
@@ -161,9 +166,9 @@ impl UseGSetObject {
             && !call.arguments.is_empty()
         {
             let new_val = call.get_arg(0)?.location().as_str()?;
-            let var_name = assign.lhs_as_text();
-            if !var_name.is_empty() {
-                return Some((var_name, new_val));
+            let var = assign.lhs.as_ref();
+            if !var.location().as_str().unwrap_or_default().is_empty() {
+                return Some((var, new_val));
             }
         }
 

--- a/src/rules/use_g_set_str.rs
+++ b/src/rules/use_g_set_str.rs
@@ -55,7 +55,7 @@ impl UseGSetStr {
         violations: &mut Vec<Violation>,
     ) -> bool {
         // First statement: g_free(var) or g_clear_pointer(&var, g_free)
-        let Some(var_name) = self.extract_gfree_var(s1) else {
+        let Some(var) = self.extract_gfree_var(s1) else {
             return false;
         };
 
@@ -64,10 +64,11 @@ impl UseGSetStr {
             return false;
         };
 
-        if assign_var != var_name {
+        if assign_var != var {
             return false;
         }
 
+        let var_name = var.location().as_str().unwrap_or_default();
         let replacement = config
             .style
             .format_addr_call_stmt("g_set_str", var_name, &[new_val]);
@@ -86,7 +87,7 @@ impl UseGSetStr {
     }
 
     /// Extract variable from g_free(var) or g_clear_pointer(&var, g_free)
-    fn extract_gfree_var<'a>(&'a self, stmt: &'a Statement) -> Option<&'a str> {
+    fn extract_gfree_var<'a>(&'a self, stmt: &'a Statement) -> Option<&'a Expression> {
         let Statement::Expression(expr_stmt) = stmt else {
             return None;
         };
@@ -96,7 +97,7 @@ impl UseGSetStr {
         };
 
         if call.is_function("g_free") {
-            return call.get_arg(0)?.location().as_str();
+            return call.get_arg(0);
         } else if call.is_function("g_clear_pointer") {
             // g_clear_pointer(&var, g_free)
             if call.arguments.len() != 2 {
@@ -119,7 +120,7 @@ impl UseGSetStr {
             if let Expression::Unary(unary) = first_arg
                 && unary.operator == UnaryOp::AddressOf
             {
-                return unary.operand.location().as_str();
+                return Some(&unary.operand);
             }
         }
 
@@ -128,7 +129,10 @@ impl UseGSetStr {
 
     /// Extract (var, new_val) from var = g_strdup(new_val) or var = cond ?
     /// g_strdup(...) : NULL
-    fn extract_strdup_assignment<'a>(&self, stmt: &'a Statement) -> Option<(&'a str, &'a str)> {
+    fn extract_strdup_assignment<'a>(
+        &self,
+        stmt: &'a Statement,
+    ) -> Option<(&'a Expression, &'a str)> {
         let Statement::Expression(expr_stmt) = stmt else {
             return None;
         };
@@ -147,9 +151,9 @@ impl UseGSetStr {
             && !call.arguments.is_empty()
         {
             let new_val = call.get_arg(0)?.location().as_str()?;
-            let var_name = assign.lhs_as_text();
-            if !var_name.is_empty() {
-                return Some((var_name, new_val));
+            let var = assign.lhs.as_ref();
+            if !var.location().as_str().unwrap_or_default().is_empty() {
+                return Some((var, new_val));
             }
         }
 
@@ -159,9 +163,9 @@ impl UseGSetStr {
         {
             // Use the condition variable as the value
             let cond_text = cond.condition.location().as_str()?;
-            let var_name = assign.lhs_as_text();
-            if !var_name.is_empty() {
-                return Some((var_name, cond_text));
+            let var = assign.lhs.as_ref();
+            if !var.location().as_str().unwrap_or_default().is_empty() {
+                return Some((var, cond_text));
             }
         }
 


### PR DESCRIPTION
Final round of this small refactoring, with a few remaining rough comparisons that I was able to find by searching by function signature. If any are left after this, there shouldn't be very many.

I have left out CallExpression::function_name and related functions, which, strictly speaking, should also be replaced by expression comparisons, but which in practice mainly involve IdentifierExpression, so comparing strings achieves the same result.