### PR TITLE
use_g_source_once: Properly match g_(idle|timeout)_add calls

### DIFF
--- a/gobject-ast/src/model/expression/mod.rs
+++ b/gobject-ast/src/model/expression/mod.rs
@@ -224,6 +224,84 @@ impl Expression {
         }
     }
 
+    /// Recursively walk all nested expressions. The closure receives
+    /// `&'s Expression`s tied to `self`'s lifetime, so references extracted
+    /// inside the closure can be stored in an outer `Vec<&'s T>`.
+    pub fn walk_with_parents<'s, F>(&'s self, parents: Option<&mut Vec<&'s Self>>, f: &mut F)
+    where
+        F: FnMut(&'s Self, &Option<&mut Vec<&'s Self>>),
+    {
+        f(self, &parents);
+
+        let vec: &mut Vec<&Self> = match parents {
+            Some(vec) => vec,
+            _ => &mut Vec::new(),
+        };
+        vec.push(self);
+
+        match self {
+            Self::Call(call) => {
+                call.function.walk_with_parents(Some(vec), f);
+                for arg in &call.arguments {
+                    arg.walk_with_parents(Some(vec), f);
+                }
+            }
+            Self::AllocCall(alloc) => {
+                alloc.function.walk_with_parents(Some(vec), f);
+                for arg in &alloc.arguments {
+                    arg.walk_with_parents(Some(vec), f);
+                }
+            }
+            Self::Assignment(assign) => {
+                assign.lhs.walk_with_parents(Some(vec), f);
+                assign.rhs.walk_with_parents(Some(vec), f);
+            }
+            Self::Unary(unary) => {
+                unary.operand.walk_with_parents(Some(vec), f);
+            }
+            Self::Binary(binary) => {
+                binary.left.walk_with_parents(Some(vec), f);
+                binary.right.walk_with_parents(Some(vec), f);
+            }
+            Self::Cast(cast) => {
+                cast.operand.walk_with_parents(Some(vec), f);
+            }
+            Self::Conditional(cond) => {
+                cond.condition.walk_with_parents(Some(vec), f);
+                cond.then_expr.walk_with_parents(Some(vec), f);
+                cond.else_expr.walk_with_parents(Some(vec), f);
+            }
+            Self::Subscript(subscript) => {
+                subscript.array.walk_with_parents(Some(vec), f);
+                subscript.index.walk_with_parents(Some(vec), f);
+            }
+            Self::Update(update) => {
+                update.operand.walk_with_parents(Some(vec), f);
+            }
+            Self::FieldAccess(field) => {
+                field.base.walk_with_parents(Some(vec), f);
+            }
+            Self::InitializerList(init) => {
+                for item in &init.items {
+                    if let Some(Designator::Subscript(idx)) = &item.designator {
+                        idx.walk_with_parents(Some(vec), f);
+                    }
+                    item.value.walk_with_parents(Some(vec), f);
+                }
+            }
+            Self::Identifier(_)
+            | Self::StringLiteral(_)
+            | Self::NumberLiteral(_)
+            | Self::Null(_)
+            | Self::Boolean(_)
+            | Self::Sizeof(_)
+            | Self::CharLiteral(_)
+            | Self::Comment(_)
+            | Self::OffsetOf(_)
+            | Self::Generic(_) => {}
+        }
+    }
+
     /// Extract variable from simple expressions (Identifier, FieldAccess or Unary)
     pub fn extract_variable(&self) -> Option<&Self> {
         match self {

--- a/src/rules/use_g_source_once.rs
+++ b/src/rules/use_g_source_once.rs
@@ -242,9 +242,12 @@ impl UseGSourceOnce {
         for stmt in statements {
             let mut found = false;
             stmt.walk(&mut |s| {
-                if !self.is_source_add_statement(s, callback_name) {
-                    s.visit_expressions(&mut |e| {
-                        if e.contains_identifier(callback_name) {
+                if let Statement::Expression(expr_stmt) = s {
+                    expr_stmt.walk_with_parents(None, &mut |child, parents| {
+                        if let Some(parents) = parents
+                            && matches!(child, Expression::Identifier(id) if id.name == callback_name)
+                            && !parents.iter().any(|p| matches!(p, Expression::Call(c) if gsource_callback_arg_index(c.function_name()).is_some()))
+                        {
                             found = true;
                         }
                     });
@@ -255,17 +258,5 @@ impl UseGSourceOnce {
             }
         }
         false
-    }
-
-    fn is_source_add_statement(&self, stmt: &Statement, callback_name: &str) -> bool {
-        if let Statement::Expression(expr_stmt) = stmt
-            && let Expression::Call(call) = expr_stmt.as_ref()
-            && let Some(idx) = gsource_callback_arg_index(call.function_name_str().unwrap_or(""))
-            && let Some(name) = call.get_arg(idx).and_then(|a| a.extract_identifier_name())
-        {
-            name == callback_name
-        } else {
-            false
-        }
     }
 }

--- a/tests/fixtures/use_g_source_once/basic.c
+++ b/tests/fixtures/use_g_source_once/basic.c
@@ -7,8 +7,26 @@ my_idle_cb (gpointer user_data)
   return G_SOURCE_REMOVE;
 }
 
+static gboolean
+my_timeout_cb (gpointer user_data)
+{
+  do_work ();
+  return G_SOURCE_REMOVE;
+}
+
+static gboolean
+my_timeout_seconds_cb (gpointer user_data)
+{
+  do_work ();
+  return G_SOURCE_REMOVE;
+}
+
 static void
 setup (void)
 {
   g_idle_add (my_idle_cb, NULL);
+
+  guint id = g_timeout_add (10, my_timeout_cb, NULL);
+
+  gpointer pid = GUINT_TO_POINTER (g_timeout_add_seconds (1, my_timeout_seconds_cb, NULL));
 }

--- a/tests/fixtures/use_g_source_once/basic.fixed.c
+++ b/tests/fixtures/use_g_source_once/basic.fixed.c
@@ -7,7 +7,23 @@ my_idle_cb (gpointer user_data)
 }
 
 static void
+my_timeout_cb (gpointer user_data)
+{
+  do_work ();
+}
+
+static void
+my_timeout_seconds_cb (gpointer user_data)
+{
+  do_work ();
+}
+
+static void
 setup (void)
 {
   g_idle_add_once (my_idle_cb, NULL);
+
+  guint id = g_timeout_add_once (10, my_timeout_cb, NULL);
+
+  gpointer pid = GUINT_TO_POINTER (g_timeout_add_seconds_once (1, my_timeout_seconds_cb, NULL));
 }

--- a/tests/fixtures/use_g_source_once/basic.stderr
+++ b/tests/fixtures/use_g_source_once/basic.stderr
@@ -1,1 +1,3 @@
-basic.c:13:3: use_g_source_once: Callback 'my_idle_cb' always returns G_SOURCE_REMOVE. Use g_idle_add_once instead of g_idle_add
+basic.c:27:3: use_g_source_once: Callback 'my_idle_cb' always returns G_SOURCE_REMOVE. Use g_idle_add_once instead of g_idle_add
+basic.c:29:14: use_g_source_once: Callback 'my_timeout_cb' always returns G_SOURCE_REMOVE. Use g_timeout_add_once instead of g_timeout_add
+basic.c:31:36: use_g_source_once: Callback 'my_timeout_seconds_cb' always returns G_SOURCE_REMOVE. Use g_timeout_add_seconds_once instead of g_timeout_add_seconds


### PR DESCRIPTION
This rule could be further refined by determining whether other uses of the GSourceFunc ignore its return value (which is likely often the case), and replacing it with a GSourceOnceFunc in those cases as well. Two false negatives reported in #137 are of this type, but this seems more like an improvement than a bug fix.

Fixes: #137