### PR TITLE
get_type_not_const: Check c files for declarations

### DIFF
--- a/src/rules/get_type_not_const.rs
+++ b/src/rules/get_type_not_const.rs
@@ -63,6 +63,22 @@ impl Rule for GetTypeNotConst {
             violations.push(self.violation_at(&file.path, &func.location, message));
         }
     }
+
+    fn check_all(
+        &self,
+        ast_context: &AstContext,
+        config: &Config,
+        violations: &mut Vec<Violation>,
+    ) {
+        for (path, file) in ast_context.iter_all_files() {
+            let ext = path.extension().and_then(|e| e.to_str());
+            if ext == Some("c") || ext == Some("h") {
+                for func in file.iter_function_declarations() {
+                    self.check_func_decl(ast_context, config, func, file, violations);
+                }
+            }
+        }
+    }
 }
 
 impl GetTypeNotConst {

--- a/tests/fixtures/get_type_not_const/basic.c
+++ b/tests/fixtures/get_type_not_const/basic.c
@@ -1,0 +1,16 @@
+#include "basic.h"
+
+/* _get_type with G_GNUC_CONST after params — should warn */
+GType my_widget_get_type (void) G_GNUC_CONST;
+
+/* _get_type with G_GNUC_CONST before return type — should warn */
+G_GNUC_CONST GType my_other_get_type (void);
+
+/* _get_type with G_GNUC_PURE after params — should warn */
+GType my_pure_get_type (void) G_GNUC_PURE;
+
+/* non-_get_type with G_GNUC_CONST — should NOT warn */
+GType not_a_get_type_func (void) G_GNUC_CONST;
+
+/* _get_type without any attribute — should NOT warn */
+GType my_normal_get_type (void);

--- a/tests/fixtures/get_type_not_const/basic.fixed.c
+++ b/tests/fixtures/get_type_not_const/basic.fixed.c
@@ -1,0 +1,16 @@
+#include "basic.h"
+
+/* _get_type with G_GNUC_CONST after params — should warn */
+GType my_widget_get_type (void);
+
+/* _get_type with G_GNUC_CONST before return type — should warn */
+GType my_other_get_type (void);
+
+/* _get_type with G_GNUC_PURE after params — should warn */
+GType my_pure_get_type (void);
+
+/* non-_get_type with G_GNUC_CONST — should NOT warn */
+GType not_a_get_type_func (void) G_GNUC_CONST;
+
+/* _get_type without any attribute — should NOT warn */
+GType my_normal_get_type (void);

--- a/tests/fixtures/get_type_not_const/basic.stderr
+++ b/tests/fixtures/get_type_not_const/basic.stderr
@@ -1,3 +1,6 @@
 basic.h:2:1: get_type_not_const: 'my_widget_get_type' is annotated with G_GNUC_CONST but _get_type functions have side effects on first call; remove the attribute
+basic.c:4:1: get_type_not_const: 'my_widget_get_type' is annotated with G_GNUC_CONST but _get_type functions have side effects on first call; remove the attribute
 basic.h:5:1: get_type_not_const: 'my_other_get_type' is annotated with G_GNUC_CONST but _get_type functions have side effects on first call; remove the attribute
+basic.c:7:1: get_type_not_const: 'my_other_get_type' is annotated with G_GNUC_CONST but _get_type functions have side effects on first call; remove the attribute
 basic.h:8:1: get_type_not_const: 'my_pure_get_type' is annotated with G_GNUC_PURE but _get_type functions have side effects on first call; remove the attribute
+basic.c:10:1: get_type_not_const: 'my_pure_get_type' is annotated with G_GNUC_PURE but _get_type functions have side effects on first call; remove the attribute


### PR DESCRIPTION
get_type can be declared on c files too for private gobject classes.