### PR TITLE
use_clear_functions: Extend g_clear_pointer use to any GDestroyNotify

### DIFF
--- a/src/rules/use_clear_functions.rs
+++ b/src/rules/use_clear_functions.rs
@@ -73,17 +73,6 @@ struct ClearMapping {
     min_version: (u32, u32),
 }
 
-macro_rules! PointerMapping {
-    ($name:literal) => {
-        ClearMapping {
-            source_func: $name,
-            replacement: ClearReplacement::Pointer,
-            null_check: NullCheck::Null,
-            min_version: (2, 28),
-        }
-    };
-}
-
 const CLEAR_MAPPINGS: &[ClearMapping] = &[
     ClearMapping {
         source_func: "close",
@@ -103,7 +92,6 @@ const CLEAR_MAPPINGS: &[ClearMapping] = &[
         null_check: NullCheck::Zero,
         min_version: (2, 56),
     },
-    PointerMapping!("g_source_destroy"),
     ClearMapping {
         source_func: "g_signal_handler_disconnect",
         replacement: ClearReplacement::SignalHandler,
@@ -160,44 +148,12 @@ const CLEAR_MAPPINGS: &[ClearMapping] = &[
         null_check: NullCheck::Null,
         min_version: (2, 28),
     },
-    PointerMapping!("g_free"),
-    PointerMapping!("g_hash_table_destroy"),
-    PointerMapping!("g_hash_table_unref"),
-    PointerMapping!("g_array_unref"),
-    PointerMapping!("g_async_queue_unref"),
-    PointerMapping!("g_byte_array_unref"),
-    PointerMapping!("g_bytes_unref"),
-    PointerMapping!("g_checksum_free"),
-    PointerMapping!("g_date_free"),
-    PointerMapping!("g_date_time_unref"),
-    PointerMapping!("g_io_channel_unref"),
-    PointerMapping!("g_key_file_free"),
-    PointerMapping!("g_option_context_free"),
-    PointerMapping!("g_ptr_array_unref"),
-    PointerMapping!("g_queue_free"),
-    PointerMapping!("g_sequence_free"),
-    PointerMapping!("g_strfreev"),
-    PointerMapping!("g_time_zone_unref"),
-    PointerMapping!("g_uri_unref"),
-    PointerMapping!("g_variant_unref"),
-    PointerMapping!("g_variant_dict_unref"),
-    PointerMapping!("g_variant_iter_unref"),
-    PointerMapping!("g_variant_type_unref"),
-    PointerMapping!("gdk_color_state_unref"),
-    PointerMapping!("gdk_event_unref"),
-    PointerMapping!("gdk_texture_downloader_free"),
-    PointerMapping!("gsk_path_unref"),
-    PointerMapping!("gsk_path_builder_unref"),
-    PointerMapping!("gsk_path_measure_unref"),
-    PointerMapping!("gsk_render_node_unref"),
-    PointerMapping!("gsk_render_replay_free"),
-    PointerMapping!("gsk_stroke_free"),
-    PointerMapping!("gsk_transform_unref"),
-    PointerMapping!("gtk_expression_unref"),
-    PointerMapping!("gtk_expression_watch_unref"),
-    PointerMapping!("gtk_tree_path_free"),
-    PointerMapping!("gtk_widget_destroy"),
-    PointerMapping!("gtk_window_destroy"),
+    ClearMapping {
+        source_func: "",
+        replacement: ClearReplacement::Pointer,
+        null_check: NullCheck::Null,
+        min_version: (2, 28),
+    },
 ];
 
 impl ClearMapping {
@@ -230,7 +186,7 @@ fn format_replacement(
     match mapping.replacement {
         ClearReplacement::Object => style.format_call_stmt("g_clear_object", &[&addr]),
         ClearReplacement::Pointer => {
-            style.format_call_stmt("g_clear_pointer", &[&addr, mapping.source_func])
+            style.format_call_stmt("g_clear_pointer", &[&addr, extra_arg.unwrap_or_default()])
         }
         ClearReplacement::HandleId => {
             style.format_call_stmt("g_clear_handle_id", &[&addr, mapping.source_func])
@@ -395,7 +351,10 @@ impl UseClearFunctions {
                 continue;
             }
 
-            if !call.is_function(mapping.source_func) {
+            if !call.is_function(mapping.source_func)
+                && !(matches!(mapping.replacement, ClearReplacement::Pointer)
+                    && call.arguments.len() == 1)
+            {
                 continue;
             }
 
@@ -411,12 +370,20 @@ impl UseClearFunctions {
             }
 
             let var_name = var.location().as_str().unwrap_or_default();
-            let extra_arg = call.get_arg_text(1);
+            let extra_arg = if matches!(mapping.replacement, ClearReplacement::Pointer) {
+                Some(call.function_name())
+            } else {
+                call.get_arg_text(1)
+            };
             let replacement = format_replacement(mapping, var_name, extra_arg, &config.style);
             let message = format!(
                 "Use {} instead of {} and {} assignment",
                 replacement.trim_end_matches(';'),
-                mapping.source_func,
+                if matches!(mapping.replacement, ClearReplacement::Pointer) {
+                    call.function_name()
+                } else {
+                    mapping.source_func
+                },
                 mapping.null_check.sentinel_desc()
             );
 
@@ -480,7 +447,11 @@ impl UseClearFunctions {
             "Use {} instead of manual {} check, {}, and {} assignment",
             replacement.trim_end_matches(';'),
             mapping.null_check.guard_desc(),
-            mapping.source_func,
+            if matches!(mapping.replacement, ClearReplacement::Pointer) {
+                extra_arg.unwrap_or_default()
+            } else {
+                mapping.source_func
+            },
             mapping.null_check.sentinel_desc()
         );
 
@@ -586,12 +557,20 @@ impl UseClearFunctions {
                     ) {
                         continue;
                     }
-                    if call.is_function(mapping.source_func) {
+                    if call.is_function(mapping.source_func)
+                        || (matches!(mapping.replacement, ClearReplacement::Pointer)
+                            && call.arguments.len() == 1)
+                    {
                         for arg in &call.arguments {
                             if let Some(arg_var) = arg.extract_casted_variable()
                                 && arg_var == var
                             {
-                                let extra = call.get_arg(1).and_then(|a| a.location().as_str());
+                                let extra =
+                                    if matches!(mapping.replacement, ClearReplacement::Pointer) {
+                                        Some(call.function_name())
+                                    } else {
+                                        call.get_arg(1).and_then(|a| a.location().as_str())
+                                    };
                                 return Some((*mapping, extra));
                             }
                         }

--- a/src/rules/use_clear_functions.rs
+++ b/src/rules/use_clear_functions.rs
@@ -78,7 +78,7 @@ macro_rules! PointerMapping {
         ClearMapping {
             source_func: $name,
             replacement: ClearReplacement::Pointer,
-            null_check: NullCheck::NullOrZero,
+            null_check: NullCheck::Null,
             min_version: (2, 28),
         }
     };
@@ -157,7 +157,7 @@ const CLEAR_MAPPINGS: &[ClearMapping] = &[
     ClearMapping {
         source_func: "g_object_unref",
         replacement: ClearReplacement::Object,
-        null_check: NullCheck::NullOrZero,
+        null_check: NullCheck::Null,
         min_version: (2, 28),
     },
     PointerMapping!("g_free"),

--- a/tests/fixtures/use_clear_functions/basic.stderr
+++ b/tests/fixtures/use_clear_functions/basic.stderr
@@ -1,5 +1,5 @@
-basic.c:7:3: use_clear_functions: Use g_clear_object (&obj) instead of manual NULL check, g_object_unref, and NULL/zero assignment
-basic.c:12:3: use_clear_functions: Use g_clear_object (&obj) instead of manual NULL check, g_object_unref, and NULL/zero assignment
-basic.c:17:3: use_clear_functions: Use g_clear_pointer (&str, g_free) instead of manual NULL check, g_free, and NULL/zero assignment
-basic.c:26:3: use_clear_functions: Use g_clear_pointer (arr_element, g_free) instead of g_free and NULL/zero assignment
-basic.c:29:3: use_clear_functions: Use g_clear_pointer (&arr_element, g_free) instead of g_free and NULL/zero assignment
+basic.c:7:3: use_clear_functions: Use g_clear_object (&obj) instead of manual NULL check, g_object_unref, and NULL assignment
+basic.c:12:3: use_clear_functions: Use g_clear_object (&obj) instead of manual NULL check, g_object_unref, and NULL assignment
+basic.c:17:3: use_clear_functions: Use g_clear_pointer (&str, g_free) instead of manual NULL check, g_free, and NULL assignment
+basic.c:26:3: use_clear_functions: Use g_clear_pointer (arr_element, g_free) instead of g_free and NULL assignment
+basic.c:29:3: use_clear_functions: Use g_clear_pointer (&arr_element, g_free) instead of g_free and NULL assignment

--- a/tests/fixtures/use_clear_functions/consecutive.stderr
+++ b/tests/fixtures/use_clear_functions/consecutive.stderr
@@ -1,3 +1,3 @@
-consecutive.c:10:5: use_clear_functions: Use g_clear_pointer (&self->display_seat_id, g_free) instead of g_free and NULL/zero assignment
-consecutive.c:23:5: use_clear_functions: Use g_clear_pointer (&self->name, g_free) instead of g_free and NULL/zero assignment
-consecutive.c:25:5: use_clear_functions: Use g_clear_pointer (&self->path, g_free) instead of g_free and NULL/zero assignment
+consecutive.c:10:5: use_clear_functions: Use g_clear_pointer (&self->display_seat_id, g_free) instead of g_free and NULL assignment
+consecutive.c:23:5: use_clear_functions: Use g_clear_pointer (&self->name, g_free) instead of g_free and NULL assignment
+consecutive.c:25:5: use_clear_functions: Use g_clear_pointer (&self->path, g_free) instead of g_free and NULL assignment

--- a/tests/fixtures/use_clear_functions/if_statements.stderr
+++ b/tests/fixtures/use_clear_functions/if_statements.stderr
@@ -1,11 +1,11 @@
-if_statements.c:6:3: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of manual NULL check, g_free, and NULL/zero assignment
-if_statements.c:12:3: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of manual NULL check, g_free, and NULL/zero assignment
-if_statements.c:18:3: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of manual NULL check, g_free, and NULL/zero assignment
+if_statements.c:6:3: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of manual NULL check, g_free, and NULL assignment
+if_statements.c:12:3: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of manual NULL check, g_free, and NULL assignment
+if_statements.c:18:3: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of manual NULL check, g_free, and NULL assignment
 if_statements.c:26:7: use_clear_functions: Use g_clear_handle_id (&c, g_source_remove) instead of g_source_remove and zero assignment
 if_statements.c:32:7: use_clear_functions: Use g_clear_handle_id (&c, g_source_remove) instead of g_source_remove and zero assignment
-if_statements.c:39:7: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of g_free and NULL/zero assignment
-if_statements.c:46:7: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of g_free and NULL/zero assignment
+if_statements.c:39:7: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of g_free and NULL assignment
+if_statements.c:46:7: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of g_free and NULL assignment
 if_statements.c:53:7: use_clear_functions: Use g_clear_handle_id (&c, g_source_remove) instead of g_source_remove and zero assignment
-if_statements.c:60:7: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of g_free and NULL/zero assignment
+if_statements.c:60:7: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of g_free and NULL assignment
 if_statements.c:67:7: use_clear_functions: Use g_clear_handle_id (&c, g_source_remove) instead of g_source_remove and zero assignment
-if_statements.c:74:7: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of g_free and NULL/zero assignment
+if_statements.c:74:7: use_clear_functions: Use g_clear_pointer (&a, g_free) instead of g_free and NULL assignment

--- a/tests/fixtures/use_clear_functions/labeled.stderr
+++ b/tests/fixtures/use_clear_functions/labeled.stderr
@@ -1,5 +1,5 @@
-labeled.c:20:3: use_clear_functions: Use g_clear_pointer (&self->name, g_free) instead of g_free and NULL/zero assignment
+labeled.c:20:3: use_clear_functions: Use g_clear_pointer (&self->name, g_free) instead of g_free and NULL assignment
 labeled.c:35:3: use_clear_functions: Use g_clear_signal_handler (&self->signal_id, self->source) instead of g_signal_handler_disconnect and zeroing the ID
 labeled.c:50:3: use_clear_functions: Use g_clear_handle_id (&self->timeout_id, g_source_remove) instead of g_source_remove and zero assignment
 labeled.c:65:3: use_clear_functions: Use g_clear_signal_handler (&self->signal_id, self->source) instead of g_signal_handler_disconnect (also zeroes the stored ID)
-labeled.c:79:3: use_clear_functions: Use g_clear_pointer (&self->name, g_free) instead of g_free and NULL/zero assignment
+labeled.c:79:3: use_clear_functions: Use g_clear_pointer (&self->name, g_free) instead of g_free and NULL assignment


### PR DESCRIPTION
A function call whose only parameter is a pointer which is reset immediately afterward, always seems to be a candidate for g_clear_pointer().