### PR TITLE
use_clear_functions: Only suggest g_clear_signal_handler if ID is reset

### DIFF
--- a/src/rules/use_clear_functions.rs
+++ b/src/rules/use_clear_functions.rs
@@ -297,18 +297,6 @@ impl UseClearFunctions {
                 }
             }
 
-            // Try signal_handler's bare member disconnect
-            if self.try_bare_disconnect_on_member(
-                &statements[i],
-                statements,
-                config,
-                file,
-                violations,
-            ) {
-                i += 1;
-                continue;
-            }
-
             // Recurse into nested blocks
             if let Statement::If(if_stmt) = &statements[i] {
                 self.check_statements(config, file, &if_stmt.then_body, violations);
@@ -830,49 +818,6 @@ impl UseClearFunctions {
         true
     }
 
-    fn try_bare_disconnect_on_member(
-        &self,
-        stmt: &Statement,
-        all_stmts: &[Statement],
-        config: &Config,
-        file: &FileModel,
-        violations: &mut Vec<Violation>,
-    ) -> bool {
-        let signal_mapping = match self.find_signal_mapping(config) {
-            Some(m) => m,
-            None => return false,
-        };
-
-        let Some((obj, handler_id)) = self.extract_disconnect_args(stmt) else {
-            return false;
-        };
-
-        let Some(base) = (match handler_id {
-            Expression::FieldAccess(f) => f.base.extract_variable(),
-            _ => None,
-        }) else {
-            return false;
-        };
-
-        if self.is_freed_in_stmts(all_stmts, base) {
-            return false;
-        }
-
-        let handler_id = handler_id.location().as_str().unwrap_or_default();
-        let obj = obj.location().as_str().unwrap_or_default();
-        let replacement = format_replacement(&signal_mapping, handler_id, Some(obj), &config.style);
-        let message = format!(
-            "Use {} instead of g_signal_handler_disconnect (also zeroes the stored ID)",
-            replacement.trim_end_matches(';')
-        );
-        let inner = stmt.inner_statement();
-        let stmt_end = inner.location().find_semicolon_end();
-        let fix = Fix::new(inner.location().start_byte, stmt_end, replacement);
-
-        violations.push(self.violation_with_fix_at(&file.path, inner.location(), message, fix));
-        true
-    }
-
     fn find_signal_mapping(&self, config: &Config) -> Option<ClearMapping> {
         CLEAR_MAPPINGS
             .iter()
@@ -910,38 +855,6 @@ impl UseClearFunctions {
         assign.lhs.as_ref() == expected_id
             && assign.operator == AssignmentOp::Assign
             && assign.rhs.is_zero()
-    }
-
-    fn is_freed_in_stmts(&self, stmts: &[Statement], target: &Expression) -> bool {
-        for stmt in stmts {
-            let Statement::Expression(expr_stmt) = stmt.inner_statement() else {
-                continue;
-            };
-
-            let Expression::Call(call) = expr_stmt.as_ref() else {
-                continue;
-            };
-
-            if !call.function_contains("free")
-                && !call.function_contains("unref")
-                && !call.function_contains("destroy")
-                && !call.function_contains("clear")
-            {
-                continue;
-            }
-
-            for arg in &call.arguments {
-                if call.function_name().starts_with("g_clear_") {
-                    if matches!(arg.as_ref(), Expression::Unary(u) if u.operator == UnaryOp::AddressOf && u.operand.as_ref() == target)
-                    {
-                        return true;
-                    }
-                } else if arg.as_ref() == target {
-                    return true;
-                }
-            }
-        }
-        false
     }
 
     fn extract_weak_pointer_var<'a>(&self, expr: &'a Expression) -> Option<&'a Expression> {

--- a/tests/fixtures/use_clear_functions/labeled.c
+++ b/tests/fixtures/use_clear_functions/labeled.c
@@ -52,20 +52,6 @@ out:
   return -1;
 }
 
-/* bare disconnect on member after a goto label */
-
-static int
-labeled_bare_disconnect (MyObj *self)
-{
-  self->signal_id = g_signal_connect (self->source, "notify", NULL, NULL);
-  if (!self->signal_id)
-    goto error;
-  return 0;
-error:
-  g_signal_handler_disconnect (self->source, self->signal_id);
-  return -1;
-}
-
 /* stmt2 (NULL assignment) has its own label */
 
 static int

--- a/tests/fixtures/use_clear_functions/labeled.fixed.c
+++ b/tests/fixtures/use_clear_functions/labeled.fixed.c
@@ -49,20 +49,6 @@ out:
   return -1;
 }
 
-/* bare disconnect on member after a goto label */
-
-static int
-labeled_bare_disconnect (MyObj *self)
-{
-  self->signal_id = g_signal_connect (self->source, "notify", NULL, NULL);
-  if (!self->signal_id)
-    goto error;
-  return 0;
-error:
-  g_clear_signal_handler (&self->signal_id, self->source);
-  return -1;
-}
-
 /* stmt2 (NULL assignment) has its own label */
 
 static int

--- a/tests/fixtures/use_clear_functions/labeled.stderr
+++ b/tests/fixtures/use_clear_functions/labeled.stderr
@@ -1,5 +1,4 @@
 labeled.c:20:3: use_clear_functions: Use g_clear_pointer (&self->name, g_free) instead of g_free and NULL assignment
 labeled.c:35:3: use_clear_functions: Use g_clear_signal_handler (&self->signal_id, self->source) instead of g_signal_handler_disconnect and zeroing the ID
 labeled.c:50:3: use_clear_functions: Use g_clear_handle_id (&self->timeout_id, g_source_remove) instead of g_source_remove and zero assignment
-labeled.c:65:3: use_clear_functions: Use g_clear_signal_handler (&self->signal_id, self->source) instead of g_signal_handler_disconnect (also zeroes the stored ID)
-labeled.c:79:3: use_clear_functions: Use g_clear_pointer (&self->name, g_free) instead of g_free and NULL assignment
+labeled.c:65:3: use_clear_functions: Use g_clear_pointer (&self->name, g_free) instead of g_free and NULL assignment

--- a/tests/fixtures/use_clear_functions/signal_handler_basic.c
+++ b/tests/fixtures/use_clear_functions/signal_handler_basic.c
@@ -61,39 +61,3 @@ clear_if_neq_zero (MyObj *self)
       self->notify_id = 0;
     }
 }
-
-/* bare disconnect on struct member — no following zero-assign */
-
-static void
-clear_bare_member (MyObj *self)
-{
-  g_signal_handler_disconnect (self->source, self->signal_id);
-}
-
-/* bare disconnect on struct member, but the struct is freed — skip */
-
-static void
-clear_bare_member_freed (MyObj *self)
-{
-  g_signal_handler_disconnect (self->source, self->signal_id);
-  g_free (self);
-}
-
-/* bare disconnect on struct member, but the struct is g_clear_object'd — skip */
-
-static void
-clear_bare_member_source_cleared (MyObj *self)
-{
-  g_signal_handler_disconnect (self->source, self->signal_id);
-  g_clear_object (&self);
-}
-
-/* bare disconnect, but the struct is freed under a label — skip */
-
-static void
-clear_bare_member_freed_labeled (MyObj *self)
-{
-  g_signal_handler_disconnect (self->source, self->signal_id);
-cleanup:
-  g_free (self);
-}

--- a/tests/fixtures/use_clear_functions/signal_handler_basic.fixed.c
+++ b/tests/fixtures/use_clear_functions/signal_handler_basic.fixed.c
@@ -46,39 +46,3 @@ clear_if_neq_zero (MyObj *self)
 {
   g_clear_signal_handler (&self->notify_id, self->source);
 }
-
-/* bare disconnect on struct member — no following zero-assign */
-
-static void
-clear_bare_member (MyObj *self)
-{
-  g_clear_signal_handler (&self->signal_id, self->source);
-}
-
-/* bare disconnect on struct member, but the struct is freed — skip */
-
-static void
-clear_bare_member_freed (MyObj *self)
-{
-  g_signal_handler_disconnect (self->source, self->signal_id);
-  g_free (self);
-}
-
-/* bare disconnect on struct member, but the struct is g_clear_object'd — skip */
-
-static void
-clear_bare_member_source_cleared (MyObj *self)
-{
-  g_signal_handler_disconnect (self->source, self->signal_id);
-  g_clear_object (&self);
-}
-
-/* bare disconnect, but the struct is freed under a label — skip */
-
-static void
-clear_bare_member_freed_labeled (MyObj *self)
-{
-  g_signal_handler_disconnect (self->source, self->signal_id);
-cleanup:
-  g_free (self);
-}

--- a/tests/fixtures/use_clear_functions/signal_handler_basic.stderr
+++ b/tests/fixtures/use_clear_functions/signal_handler_basic.stderr
@@ -4,4 +4,3 @@ signal_handler_basic.c:25:3: use_clear_functions: Use g_clear_signal_handler (&s
 signal_handler_basic.c:34:3: use_clear_functions: Use g_clear_signal_handler (&self->signal_id, self->source) instead of if-guarded g_signal_handler_disconnect
 signal_handler_basic.c:46:3: use_clear_functions: Use g_clear_signal_handler (&self->signal_id, self->source) instead of if-guarded g_signal_handler_disconnect
 signal_handler_basic.c:58:3: use_clear_functions: Use g_clear_signal_handler (&self->notify_id, self->source) instead of if-guarded g_signal_handler_disconnect
-signal_handler_basic.c:70:3: use_clear_functions: Use g_clear_signal_handler (&self->signal_id, self->source) instead of g_signal_handler_disconnect (also zeroes the stored ID)


### PR DESCRIPTION
This is consistent with the current description of this rule: "Suggest g_clear_* functions instead of manual cleanup *and* NULL/zero assignment"
and g_clear_signal_handler() is the only function for which this suggestion is made even when the ID is not reset.

Another possibility is to add an option to enable the suggestion even when the id/pointer is not reset, but I suppose that would then have to be done for all g_clear_* functions. I'm not sure how useful or welcome this suggestion is… (personally, I would disable it)

Closes: #138