### PR TITLE
use_clear_functions: Restrict g_clear_pointer to non casted variables

### DIFF
--- a/src/rules/use_clear_functions.rs
+++ b/src/rules/use_clear_functions.rs
@@ -350,6 +350,7 @@ impl UseClearFunctions {
                 ClearReplacement::WeakPointer => {
                     self.extract_weak_pointer_var(call.arguments.get(1)?)?
                 }
+                ClearReplacement::Pointer => call.get_arg(0)?.extract_variable()?,
                 _ => call.get_arg(0)?.extract_casted_variable()?,
             };
 
@@ -545,23 +546,22 @@ impl UseClearFunctions {
                     ) {
                         continue;
                     }
-                    if call.is_function(mapping.source_func)
-                        || (matches!(mapping.replacement, ClearReplacement::Pointer)
-                            && call.arguments.len() == 1)
-                    {
+                    if call.is_function(mapping.source_func) {
                         for arg in &call.arguments {
                             if let Some(arg_var) = arg.extract_casted_variable()
                                 && arg_var == var
                             {
-                                let extra =
-                                    if matches!(mapping.replacement, ClearReplacement::Pointer) {
-                                        Some(call.function_name())
-                                    } else {
-                                        call.get_arg(1).and_then(|a| a.location().as_str())
-                                    };
+                                let extra = call.get_arg(1).and_then(|a| a.location().as_str());
                                 return Some((*mapping, extra));
                             }
                         }
+                    } else if matches!(mapping.replacement, ClearReplacement::Pointer)
+                        && call.arguments.len() == 1
+                        && let Some(arg_var) = call.get_arg(0)?.extract_variable()
+                        && arg_var == var
+                    {
+                        let extra = Some(call.function_name());
+                        return Some((*mapping, extra));
                     }
                 }
             }

--- a/tests/fixtures/use_clear_functions/basic.c
+++ b/tests/fixtures/use_clear_functions/basic.c
@@ -25,7 +25,4 @@ clear_string (gchar **arr_element)
 {
   g_free (*arr_element);
   *arr_element = NULL;
-
-  g_free ((gpointer) arr_element);
-  arr_element = NULL;
 }

--- a/tests/fixtures/use_clear_functions/basic.fixed.c
+++ b/tests/fixtures/use_clear_functions/basic.fixed.c
@@ -15,6 +15,4 @@ static void
 clear_string (gchar **arr_element)
 {
   g_clear_pointer (arr_element, g_free);
-
-  g_clear_pointer (&arr_element, g_free);
 }

--- a/tests/fixtures/use_clear_functions/basic.stderr
+++ b/tests/fixtures/use_clear_functions/basic.stderr
@@ -2,4 +2,3 @@ basic.c:7:3: use_clear_functions: Use g_clear_object (&obj) instead of manual NU
 basic.c:12:3: use_clear_functions: Use g_clear_object (&obj) instead of manual NULL check, g_object_unref, and NULL assignment
 basic.c:17:3: use_clear_functions: Use g_clear_pointer (&str, g_free) instead of manual NULL check, g_free, and NULL assignment
 basic.c:26:3: use_clear_functions: Use g_clear_pointer (arr_element, g_free) instead of g_free and NULL assignment
-basic.c:29:3: use_clear_functions: Use g_clear_pointer (&arr_element, g_free) instead of g_free and NULL assignment


### PR DESCRIPTION
Fixes: #175