### PR TITLE
use_clear_functions: Better detect cast macros

### DIFF
--- a/gobject-ast/src/model/expression/mod.rs
+++ b/gobject-ast/src/model/expression/mod.rs
@@ -320,7 +320,7 @@ impl Expression {
     /// `G_OBJECT(self)` → `"self"`, `(GSourceFunc) callback` → `"callback"`
     pub fn extract_casted_variable(&self) -> Option<&Self> {
         match self {
-            Self::Call(call) => call.get_arg(0)?.extract_variable(),
+            Self::Call(call) if call.is_likely_macro() => call.get_arg(0)?.extract_variable(),
             Self::Cast(cast) => cast.operand.extract_variable(),
             _ => self.extract_variable(),
         }


### PR DESCRIPTION
If this continues to cause problems after that, I suppose we could just stop checking for casts in `use_clear_functions`.

Fixes: #178