### PR TITLE
config: Honor user-set level as much as possible with --only

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -470,7 +470,14 @@ impl Config {
                 {
                     $(
                         self.rules.$config_field.level = Some(if rule_names.iter().any(|r| r.as_str() == stringify!($config_field)) {
-                            RuleLevel::Error
+                            let default_level = match self.default_level {
+                                None | Some(RuleLevel::Ignore) => RuleLevel::Warn,
+                                Some(level) => level,
+                            };
+                            match self.rules.$config_field.level {
+                                None | Some(RuleLevel::Ignore) => default_level,
+                                Some(level) => level,
+                            }
                         } else {
                             RuleLevel::Ignore
                         });


### PR DESCRIPTION
This option is supposed to override the settings, but that simply means it must enable the rule passed as an argument unconditionally, not that it must completely ignore the settings or default values. Therefore:
* If the rule is already enabled, nothing changes;
* If it is disabled, it is enabled with the default level, which may be defined in the settings.

Fixes: #136