### PR TITLE
config: Only disable other rules with --category

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -512,11 +512,9 @@ impl Config {
             ($(($config_field:ident, $rule_type:ident)),* $(,)?) => {
                 {
                     $(
-                        self.rules.$config_field.level = Some(if $rule_type.category() == category {
-                            RuleLevel::Error
-                        } else {
-                            RuleLevel::Ignore
-                        });
+                        if $rule_type.category() != category {
+                            self.rules.$config_field.level = Some(RuleLevel::Ignore);
+                        }
                     )*
                 }
             };


### PR DESCRIPTION
--help does not state that --category overrides user settings, so this seems to be the simplest way to honor those settings while adhering to the description. Note that opt-in rules will not be enabled with this change if the user has not enabled them in their settings, and any rules the user has disabled will remain disabled.